### PR TITLE
fix: update typings path for @chevrotain/utils

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -10,7 +10,7 @@
   "author": {
     "name": "Shahar Soel"
   },
-  "typings": "api.d.ts",
+  "typings": "lib/src/api.d.ts",
   "main": "lib/src/api.js",
   "files": [
     "lib/src/api.js",


### PR DESCRIPTION
Build currently works because it implicitly converts them to `any`.

Might be worth enabling `noImplicitAny` or `strict` in `tsconfig.json` to capture these cases in the future.  Might be a bit of work though.  ~500 errors when I enabled `noImplicitAny` locally.