### PR TITLE
Exclude __esModule from esm wrapper 

### DIFF
--- a/packages/chevrotain/package.json
+++ b/packages/chevrotain/package.json
@@ -79,7 +79,7 @@
     "@types/sinon-chai": "^3.2.0",
     "error-stack-parser": "^2.0.6",
     "esbuild": "^0.11.1",
-    "gen-esm-wrapper": "^1.0.4",
+    "gen-esm-wrapper": "^1.1.2",
     "gitty": "^3.6.0",
     "jsdom": "16.4.0",
     "jsonfile": "^6.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6104,10 +6104,10 @@ gauge@~2.7.3:
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
 
-gen-esm-wrapper@^1.0.4:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/gen-esm-wrapper/-/gen-esm-wrapper-1.1.1.tgz#1e4d508d0229284490f101d22ac33e09435f80fb"
-  integrity sha512-/ZMuX3itPtnjjWuIArzBi6mDnkGVcsx8guLCeH3WLB+iLeFr8TOKhIrNaYmPuRtQcpeBKrlswCPAY9oLRKIxKw==
+gen-esm-wrapper@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/gen-esm-wrapper/-/gen-esm-wrapper-1.1.2.tgz#ea91a4f0dae497060bd9462d8a9bc5bc2dacc3d0"
+  integrity sha512-ZzqvusFKGZEWunpoz5Yg4+tdODUa7Swv1pvd83VF9nVJNCIu5i1KJ6pFjTFFkvk8deeSWLdMgc8FNRaTe5MTTA==
   dependencies:
     is-valid-identifier "^2.0.2"
 


### PR DESCRIPTION
I'm pretty sure `gen-esm-wrapper` should automatically exclude `__esModule` but at least it gives us a way to do it without updating the library.

Fixes #1537