### PR TITLE
fix(lexer): allow unicode sequences in tokens

### DIFF
--- a/packages/chevrotain/src/scan/lexer.ts
+++ b/packages/chevrotain/src/scan/lexer.ts
@@ -812,14 +812,16 @@ function noMetaChar(regExp: RegExp): boolean {
 }
 
 export function addStartOfInput(pattern: RegExp): RegExp {
-  const flags = pattern.ignoreCase ? "i" : ""
+  const baseflags = pattern.ignoreCase ? "i" : ""
+  const flags = pattern?.flags?.includes("u") ? `${baseflags}u` : baseflags
   // always wrapping in a none capturing group preceded by '^' to make sure matching can only work on start of input.
   // duplicate/redundant start of input markers have no meaning (/^^^^A/ === /^A/)
   return new RegExp(`^(?:${pattern.source})`, flags)
 }
 
 export function addStickyFlag(pattern: RegExp): RegExp {
-  const flags = pattern.ignoreCase ? "iy" : "y"
+  const baseflags = pattern.ignoreCase ? "iy" : "y"
+  const flags = pattern?.flags?.includes("u") ? `${baseflags}u` : baseflags
   // always wrapping in a none capturing group preceded by '^' to make sure matching can only work on start of input.
   // duplicate/redundant start of input markers have no meaning (/^^^^A/ === /^A/)
   return new RegExp(`${pattern.source}`, flags)


### PR DESCRIPTION
Allow tokens to use patterns like '/\u{10334}/u'
Change addStartOfInput and addStickyFlag to keep the 'u' flag

Fixes [#1620](https://github.com/Chevrotain/chevrotain/issues/1620)