### PR TITLE
Fix parser not supporting tokens with names equal to any method on the object prototype

### DIFF
--- a/packages/chevrotain/src/parse/cst/cst.ts
+++ b/packages/chevrotain/src/parse/cst/cst.ts
@@ -67,7 +67,7 @@ export function addTerminalToCst(
   token: IToken,
   tokenTypeName: string
 ): void {
-  if (node.children[tokenTypeName] === undefined) {
+  if (!node.children.hasOwnProperty(tokenTypeName)) {
     node.children[tokenTypeName] = [token]
   } else {
     node.children[tokenTypeName].push(token)


### PR DESCRIPTION
See [this comment](https://github.com/Chevrotain/chevrotain/issues/1724#issuecomment-996898017) for a better explanation.

Super simple fix, simply ensures that we check if the `node.children` object has the key itself, so we don't get the wrong result if the key exists on its prototype (e.g. `"constructor"`, `"toString"`, `"hasOwnProperty"`, ...)

Fixes #1724 