### PR TITLE
docs: change angle brackets to backticks in comment

### DIFF
--- a/packages/types/api.d.ts
+++ b/packages/types/api.d.ts
@@ -157,7 +157,7 @@ declare abstract class BaseParser {
    * A Parsing DSL method use to consume a single Token.
    * In EBNF terms this is equivalent to a Terminal.
    *
-   * A Token will be consumed, IFF the next token in the token vector matches <tokType>.
+   * A Token will be consumed, IFF the next token in the token vector matches `tokType`.
    * otherwise the parser may attempt to perform error recovery (if enabled).
    *
    * The index in the method name indicates the unique occurrence of a terminal consumption


### PR DESCRIPTION
This change was done b/c the angle brackets break the compiler for [typedoc-plugin-markdown](https://github.com/tgreyuk/typedoc-plugin-markdown), a library for converting Typedoc to markdown. It interprets the angle brackets as an HTML tag, whereas it's just being used for emphasis.

This issue occurred specifically when using [docusaurus-plugin-typedoc](https://www.npmjs.com/package/docusaurus-plugin-typedoc). More details about this problem can be found here - https://github.com/tgreyuk/typedoc-plugin-markdown/issues/276

This change fixes the issues by replacing the backticks (`<` and `>`) with markdown backticks to highlight the word and achieve the same desired emphasis without breaking the markdown parser.

i was able to validate that this works in my local environment.