### PR TITLE
LL(*): Fix ECMA5 prediction and backtracking tests

### DIFF
--- a/examples/grammars/ecma5/ecma5_parser.js
+++ b/examples/grammars/ecma5/ecma5_parser.js
@@ -365,12 +365,18 @@ class ECMAScript5Parser extends EmbeddedActionsParser {
             { ALT: () => $.SUBRULE($.EmptyStatement) },
             // "LabelledStatement" must appear before "ExpressionStatement" due to common lookahead prefix ("inner :" vs "inner")
             { ALT: () => $.SUBRULE($.LabelledStatement) },
-            // The ambiguity is resolved by the ordering of the alternatives
+            // The ambiguity is resolved by using a syntactic predicate
             // See: https://ecma-international.org/ecma-262/5.1/#sec-12.4
             //   - [lookahead ∉ {{, function}]
             {
-              ALT: () => $.SUBRULE($.ExpressionStatement),
-              IGNORE_AMBIGUITIES: true
+              GATE: () => {
+                var token = this.LA(1)
+                return (
+                  token.tokenTypeIdx !== t.LCurly.tokenTypeIdx &&
+                  token.tokenTypeIdx !== t.FunctionTok.tokenTypeIdx
+                )
+              },
+              ALT: () => $.SUBRULE($.ExpressionStatement)
             },
             { ALT: () => $.SUBRULE($.IfStatement) },
             { ALT: () => $.SUBRULE($.IterationStatement) },
@@ -797,10 +803,18 @@ class ECMAScript5Parser extends EmbeddedActionsParser {
           // FunctionDeclaration appearing before statement implements [lookahead != {{, function}] in ExpressionStatement
           // See https://www.ecma-international.org/ecma-262/5.1/index.html#sec-12.4Declaration
           {
-            ALT: () => $.SUBRULE($.FunctionDeclaration),
-            IGNORE_AMBIGUITIES: true
+            ALT: () => $.SUBRULE($.FunctionDeclaration)
           },
-          { ALT: () => $.SUBRULE($.Statement) }
+          {
+            GATE: () => {
+              var token = this.LA(1)
+              return (
+                token.tokenTypeIdx !== t.LCurly.tokenTypeIdx &&
+                token.tokenTypeIdx !== t.FunctionTok.tokenTypeIdx
+              )
+            },
+            ALT: () => $.SUBRULE($.Statement)
+          }
         ])
       })
     })

--- a/packages/chevrotain/src/parse/grammar/atn.ts
+++ b/packages/chevrotain/src/parse/grammar/atn.ts
@@ -179,19 +179,6 @@ export class RuleTransition extends AbstractTransition {
   }
 }
 
-export class PredicateTransition extends AbstractTransition {
-  predicate: () => boolean
-
-  constructor(target: ATNState, predicate: () => boolean) {
-    super(target)
-    this.predicate = predicate
-  }
-
-  isEpsilon() {
-    return true
-  }
-}
-
 export interface ATNHandle {
   left: ATNState
   right: ATNState
@@ -255,36 +242,11 @@ function atom(
     return repetitionMandatory(atn, rule, production)
   } else if (production instanceof RepetitionMandatoryWithSeparator) {
     return repetitionMandatorySep(atn, rule, production)
-  } else if (production instanceof Alternative) {
-    return alternative(atn, rule, production)
-  } else if (production instanceof Rule) {
+  } else if (production instanceof Rule || production instanceof Alternative) {
     return block(atn, rule, production)
   } else {
     throw new Error("Invalid atom")
   }
-}
-
-function alternative(
-  atn: ATN,
-  rule: Rule,
-  alternative: Alternative
-): ATNHandle | undefined {
-  const handle = block(atn, rule, alternative)
-  if (alternative.predicate !== undefined && handle !== undefined) {
-    const { left, right } = handle
-    const predicateState = newState<BasicState>(atn, rule, {
-      type: ATN_BASIC
-    })
-    addTransition(
-      predicateState,
-      new PredicateTransition(left, alternative.predicate)
-    )
-    return {
-      left: predicateState,
-      right: right
-    }
-  }
-  return handle
 }
 
 function repetition(atn: ATN, rule: Rule, repetition: Repetition): ATNHandle {

--- a/packages/chevrotain/src/parse/grammar/atn.ts
+++ b/packages/chevrotain/src/parse/grammar/atn.ts
@@ -9,11 +9,10 @@ import {
   RepetitionMandatory,
   Repetition,
   Terminal,
-  AbstractProduction,
   Alternative,
   RepetitionWithSeparator,
   RepetitionMandatoryWithSeparator
-} from "./gast/gast_public"
+} from "@chevrotain/gast"
 
 export interface ATN {
   states: ATNState[]
@@ -349,7 +348,7 @@ function option(atn: ATN, rule: Rule, option: Option): ATNHandle {
 function block(
   atn: ATN,
   rule: Rule,
-  block: AbstractProduction
+  block: { definition: IProduction[] }
 ): ATNHandle | undefined {
   const handles = filter(
     map(block.definition, (e) => atom(atn, rule, e)),

--- a/packages/chevrotain/src/parse/grammar/atn_simulator.ts
+++ b/packages/chevrotain/src/parse/grammar/atn_simulator.ts
@@ -12,7 +12,14 @@ import {
   RuleTransition,
   Transition
 } from "./atn"
-import { ATNConfig, ATNConfigSet, DFA, DFAState, DFA_ERROR, getATNConfigKey } from "./dfa"
+import {
+  ATNConfig,
+  ATNConfigSet,
+  DFA,
+  DFAState,
+  DFA_ERROR,
+  getATNConfigKey
+} from "./dfa"
 import min from "lodash/min"
 import map from "lodash/map"
 
@@ -188,7 +195,7 @@ export class ATNSimulator {
         const target = this.getReachableTarget(transition, token)
         if (target !== undefined) {
           intermediate.add({
-            state: target.state,
+            state: target,
             alt: c.alt,
             stack: c.stack
           })
@@ -226,15 +233,12 @@ export class ATNSimulator {
   getReachableTarget(
     transition: Transition,
     token: IToken
-  ): { state: ATNState; type: TokenType } | undefined {
+  ): ATNState | undefined {
     if (
       transition instanceof AtomTransition &&
       tokenStructuredMatcher(token, transition.tokenType)
     ) {
-      return {
-        state: transition.target,
-        type: transition.tokenType
-      }
+      return transition.target
     }
     return undefined
   }
@@ -303,6 +307,7 @@ export class ATNSimulator {
     if (existing !== undefined) {
       return existing
     }
+    state.configs.finalize()
     dfa.states[mapKey] = state
     return state
   }

--- a/packages/chevrotain/src/parse/grammar/dfa.ts
+++ b/packages/chevrotain/src/parse/grammar/dfa.ts
@@ -11,7 +11,6 @@ export interface DFA {
 
 export interface DFAState {
   stateNumber: number
-  predicates?: (Predicate | undefined)[]
   configs: ATNConfigSet
   edges: Record<number, DFAState>
   isAcceptState: boolean
@@ -23,7 +22,7 @@ export const DFA_ERROR = {} as DFAState
 export interface ATNConfig {
   state: ATNState
   alt: number
-  followState?: ATNState
+  stack: ATNState[]
 }
 
 export class ATNConfigSet {

--- a/packages/chevrotain/src/parse/grammar/dfa.ts
+++ b/packages/chevrotain/src/parse/grammar/dfa.ts
@@ -33,9 +33,19 @@ export class ATNConfigSet {
     return this.configs.length
   }
 
+  finalize(): void {
+    // Empties the map to free up memory
+    this.map = {}
+  }
+
   add(config: ATNConfig): void {
-    this.map[getATNConfigKey(config)] = this.configs.length
-    this.configs.push(config)
+    const key = getATNConfigKey(config)
+    // Only add configs which don't exist in our map already
+    // While this does not influence the actual algorithm, adding them anyway would massively increase memory consumption
+    if (!(key in this.map)) {
+      this.map[key] = this.configs.length
+      this.configs.push(config)
+    }
   }
 
   get(index: number): ATNConfig {
@@ -64,5 +74,7 @@ export class ATNConfigSet {
 }
 
 export function getATNConfigKey(config: ATNConfig) {
-	return `${config.state.stateNumber}_${config.alt}:${config.stack.map(e => e.stateNumber.toString()).join('_')}`;
+  return `${config.state.stateNumber}_${config.alt}:${config.stack
+    .map((e) => e.stateNumber.toString())
+    .join("_")}`
 }

--- a/packages/chevrotain/src/parse/grammar/dfa.ts
+++ b/packages/chevrotain/src/parse/grammar/dfa.ts
@@ -1,16 +1,14 @@
 import map from "lodash/map"
-import { Predicate } from "../parser/parser"
 import { ATNState, DecisionState } from "./atn"
 
 export interface DFA {
   start?: DFAState
-  states: Map<string, DFAState>
+  states: Record<string, DFAState>
   decision: number
   atnStartState: DecisionState
 }
 
 export interface DFAState {
-  stateNumber: number
   configs: ATNConfigSet
   edges: Record<number, DFAState>
   isAcceptState: boolean
@@ -26,7 +24,7 @@ export interface ATNConfig {
 }
 
 export class ATNConfigSet {
-  private map = new Map<string, number>()
+  private map: Record<string, number> = {}
   private configs: ATNConfig[] = []
 
   uniqueAlt: number | undefined
@@ -36,7 +34,7 @@ export class ATNConfigSet {
   }
 
   add(config: ATNConfig): void {
-    this.map.set(this.atnConfigToString(config), this.configs.length)
+    this.map[getATNConfigKey(config)] = this.configs.length
     this.configs.push(config)
   }
 
@@ -56,11 +54,15 @@ export class ATNConfigSet {
     return map(this.configs, (e) => e.alt)
   }
 
-  private atnConfigToString(config: ATNConfig) {
-    return `${config.state.stateNumber}_${config.alt}`
-  }
-
   get key(): string {
-    return Array.from(this.map.keys()).join(":")
+    let value = ""
+    for (const k in this.map) {
+      value += k + ":"
+    }
+    return value
   }
+}
+
+export function getATNConfigKey(config: ATNConfig) {
+	return `${config.state.stateNumber}_${config.alt}:${config.stack.map(e => e.stateNumber.toString()).join('_')}`;
 }

--- a/packages/chevrotain/src/parse/grammar/lookahead.ts
+++ b/packages/chevrotain/src/parse/grammar/lookahead.ts
@@ -111,10 +111,11 @@ export function buildDFALookaheadFuncForOr(
       }
     }
   } else if (hasPredicates) {
+    const length = alternation.definition.length
     return function (orAlts) {
       if (orAlts) {
         const predicates = new PredicateSet()
-        for (let i = 0; i < orAlts.length; i++) {
+        for (let i = 0; i < length; i++) {
           const gate = orAlts[i].GATE
           predicates.set(i, gate === undefined || gate.call(this))
         }

--- a/packages/chevrotain/src/parse/grammar/lookahead.ts
+++ b/packages/chevrotain/src/parse/grammar/lookahead.ts
@@ -29,7 +29,7 @@ import {
   IProductionWithOccurrence,
   TokenType
 } from "@chevrotain/types"
-import { ATNSimulator } from "./atn_simulator"
+import { ATNSimulator, PredicateSet } from "./atn_simulator"
 
 export enum PROD_TYPE {
   OPTION,
@@ -58,6 +58,8 @@ export function getProdType(prod: IProduction): PROD_TYPE {
     throw Error("non exhaustive match")
   }
 }
+
+const EMPTY_PREDICATES = new PredicateSet()
 
 export function buildDFALookaheadFuncForOr(
   atnSimulator: ATNSimulator,
@@ -108,9 +110,22 @@ export function buildDFALookaheadFuncForOr(
         return choiceToAlt[nextToken.tokenTypeIdx]
       }
     }
+  } else if (hasPredicates) {
+    return function (orAlts) {
+      if (orAlts) {
+        const predicates = new PredicateSet()
+        for (let i = 0; i < orAlts.length; i++) {
+          const gate = orAlts[i].GATE
+          predicates.set(i, gate === undefined || gate.call(this))
+        }
+        return atnSimulator.adaptivePredict(decisionIndex, predicates)
+      } else {
+        return atnSimulator.adaptivePredict(decisionIndex, EMPTY_PREDICATES)
+      }
+    }
   } else {
     return function () {
-      return atnSimulator.adaptivePredict(decisionIndex, hasPredicates)
+      return atnSimulator.adaptivePredict(decisionIndex, EMPTY_PREDICATES)
     }
   }
 }
@@ -130,12 +145,6 @@ export function buildDFALookaheadFuncForOptionalProd(
       return map(e, (g) => g[0])
     }
   )
-
-  // const lookAheadPaths = getLookaheadPathsForOr(
-  //   occurrence,
-  //   ruleGrammar,
-  //   1
-  // )
 
   if (isLL1Sequence(alts) && !dynamicTokensEnabled) {
     const alt = alts[0]
@@ -173,7 +182,7 @@ export function buildDFALookaheadFuncForOptionalProd(
     }
   }
   return function () {
-    return atnSimulator.adaptivePredict(decisionIndex, false) === 0
+    return atnSimulator.adaptivePredict(decisionIndex, EMPTY_PREDICATES) === 0
   }
 }
 

--- a/packages/chevrotain/src/parse/parser/traits/looksahead.ts
+++ b/packages/chevrotain/src/parse/parser/traits/looksahead.ts
@@ -35,7 +35,7 @@ import {
   RepetitionWithSeparator,
   Rule
 } from "@chevrotain/gast"
-import { collectMethods, getProductionDslName } from "@chevrotain/gast"
+import { getProductionDslName } from "@chevrotain/gast"
 import {
   ATN,
   ATNState,

--- a/packages/chevrotain/test/parse/grammar/atn_spec.ts
+++ b/packages/chevrotain/test/parse/grammar/atn_spec.ts
@@ -7,7 +7,7 @@ import {
   Repetition,
   Rule,
   Terminal
-} from "../../../src/parse/grammar/gast/gast_public"
+} from "@chevrotain/gast"
 import {
   ATN,
   ATNState,


### PR DESCRIPTION
Does three things:

1. Adds syntactic predicates to the ECMA5 parsers to correctly work with ambiguities and LL(*)
2. Fixes backtracking tests by adding a stricter heuristic for ambiguities
3. Changes the order of predicate evaluation. Instead of evaluating them at the end like Antlr does, we evaluate them at the start and create a distinct DFA for each configuration of predicates.