### PR TITLE
Fix syntax of Markdown links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ## Introduction
 
-Chevrotain is a [**blazing fast**][https://chevrotain.io/performance/] and [**feature rich**](http://chevrotain.io/docs/features/blazing_fast.html) **Parser Building Toolkit** for **JavaScript**.
+Chevrotain is a [**blazing fast**](https://chevrotain.io/performance/) and [**feature rich**](http://chevrotain.io/docs/features/blazing_fast.html) **Parser Building Toolkit** for **JavaScript**.
 It can be used to build parsers/compilers/interpreters for various use cases ranging from simple configuration files,
 to full-fledged programing languages.
 
@@ -22,7 +22,7 @@ as any other pure code without requiring any new tools or processes.
 
 - [**Online Playground**](https://chevrotain.io/playground/)
 - **[Getting Started Tutorial](https://chevrotain.io/docs/tutorial/step0_introduction.html)**
-- [**Performance benchmark**][https://chevrotain.io/performance/]
+- [**Performance benchmark**](https://chevrotain.io/performance/)
 
 ## Installation
 


### PR DESCRIPTION
Fixes a silly syntax mistake I made in my previous pull request (#1763), where I set out to fix a little mistake introduced in the commit f03468fe13b5bca56ea7abaf83f000033760ef94. I've tested my changes this time, sorry!