### PR TITLE
fix: suppress Firefox warning of unreachable code

### DIFF
--- a/packages/utils/src/to-fast-properties.ts
+++ b/packages/utils/src/to-fast-properties.ts
@@ -15,7 +15,10 @@ export function toFastProperties(toBecomeFast: any) {
   fakeAccess()
   fakeAccess()
 
-  return toBecomeFast
+  // Always true condition to suppress the Firefox warning of unreachable
+  // code after a return statement.
+  if (1) return toBecomeFast
+
   // Eval prevents optimization of this method (even though this is dead code)
   /* istanbul ignore next */
   // tslint:disable-next-line


### PR DESCRIPTION
I tested it with the benchmark_web/index_next.html in Firefox and it seems to work.

Fixes #1787 