### PR TITLE
feat(lexer): added recoveryEnabled option to the Lexer class configuration

### DIFF
--- a/packages/chevrotain/src/scan/lexer_public.ts
+++ b/packages/chevrotain/src/scan/lexer_public.ts
@@ -524,11 +524,10 @@ export class Lexer {
     push_mode.call(this, initialMode)
 
     let currConfig!: IPatternConfig
-    let failedBeforeEnd = false
 
-    const lexerConfig = this.config
+    const recoveryEnabled = this.config.recoveryEnabled
 
-    while (offset < orgLength && !failedBeforeEnd) {
+    while (offset < orgLength) {
       matchedImage = null
 
       const nextCharCode = orgText.charCodeAt(offset)
@@ -693,13 +692,9 @@ export class Lexer {
         const errorStartOffset = offset
         const errorLine = line
         const errorColumn = column
-        let foundResyncPoint = false
+        let foundResyncPoint = !recoveryEnabled
 
-        if (!lexerConfig.recoveryEnabled) {
-          failedBeforeEnd = true
-        }
-
-        while (!failedBeforeEnd && !foundResyncPoint && offset < orgLength) {
+        while (!foundResyncPoint && offset < orgLength) {
           // drop chars until we succeed in matching something
           droppedChar = orgText.charCodeAt(offset)
           // Identity Func (when sticky flag is enabled)
@@ -751,6 +746,8 @@ export class Lexer {
           length: errLength,
           message: msg
         })
+
+        if (!recoveryEnabled) break
       }
     }
 

--- a/packages/chevrotain/src/scan/lexer_public.ts
+++ b/packages/chevrotain/src/scan/lexer_public.ts
@@ -78,7 +78,8 @@ const DEFAULT_LEXER_CONFIG: Required<ILexerConfig> = {
   safeMode: false,
   errorMessageProvider: defaultLexerErrorProvider,
   traceInitPerf: false,
-  skipValidations: false
+  skipValidations: false,
+  recoveryEnabled: true
 }
 
 Object.freeze(DEFAULT_LEXER_CONFIG)
@@ -690,7 +691,11 @@ export class Lexer {
         const errorLine = line
         const errorColumn = column
         let foundResyncPoint = false
-        while (!foundResyncPoint && offset < orgLength) {
+        while (
+          this.config.recoveryEnabled &&
+          !foundResyncPoint &&
+          offset < orgLength
+        ) {
           // drop chars until we succeed in matching something
           droppedChar = orgText.charCodeAt(offset)
           // Identity Func (when sticky flag is enabled)

--- a/packages/chevrotain/src/scan/lexer_public.ts
+++ b/packages/chevrotain/src/scan/lexer_public.ts
@@ -524,8 +524,11 @@ export class Lexer {
     push_mode.call(this, initialMode)
 
     let currConfig!: IPatternConfig
+    let failedBeforeEnd = false
 
-    while (offset < orgLength) {
+    const lexerConfig = this.config
+
+    while (offset < orgLength && !failedBeforeEnd) {
       matchedImage = null
 
       const nextCharCode = orgText.charCodeAt(offset)
@@ -691,11 +694,12 @@ export class Lexer {
         const errorLine = line
         const errorColumn = column
         let foundResyncPoint = false
-        while (
-          this.config.recoveryEnabled &&
-          !foundResyncPoint &&
-          offset < orgLength
-        ) {
+
+        if (!lexerConfig.recoveryEnabled) {
+          failedBeforeEnd = true
+        }
+
+        while (!failedBeforeEnd && !foundResyncPoint && offset < orgLength) {
           // drop chars until we succeed in matching something
           droppedChar = orgText.charCodeAt(offset)
           // Identity Func (when sticky flag is enabled)

--- a/packages/chevrotain/test/scan/lexer_spec.ts
+++ b/packages/chevrotain/test/scan/lexer_spec.ts
@@ -1336,6 +1336,91 @@ function defineLexerSpecs(
         expect(tokenMatcher(lexResult.tokens[0], If)).to.be.true
       })
 
+      it("can be configured to abort any further scanning when it encounters an invalid character input", () => {
+        const ifElseLexer = new Lexer(
+          [
+            Keyword,
+            If,
+            Else,
+            Return,
+            Integer,
+            Punctuation,
+            LParen,
+            RParen,
+            Whitespace,
+            NewLine
+          ],
+          {
+            ...lexerConfig,
+            recoveryEnabled: false
+          }
+        )
+
+        const input = "if (666) return 1@#$@#$\n" + "\telse return 2"
+
+        const lexResult = ifElseLexer.tokenize(input)
+
+        expect(lexResult.errors.length).to.equal(1)
+        expect(lexResult.errors[0].message).to.contain("@")
+        if (testStart) {
+          expect(lexResult.errors[0].line).to.equal(1)
+          expect(lexResult.errors[0].column).to.equal(18)
+        } else {
+          expect(lexResult.errors[0].line).to.be.undefined
+          expect(lexResult.errors[0].column).to.be.undefined
+        }
+
+        expect(lexResult.tokens.length).to.equal(6)
+
+        expect(lexResult.tokens[0].image).to.equal("if")
+        expect(lexResult.tokens[0].startOffset).to.equal(0)
+        if (testStart) {
+          expect(lexResult.tokens[0].startLine).to.equal(1)
+          expect(lexResult.tokens[0].startColumn).to.equal(1)
+        }
+        expect(tokenMatcher(lexResult.tokens[0], If)).to.be.true
+
+        expect(lexResult.tokens[1].image).to.equal("(")
+        expect(lexResult.tokens[1].startOffset).to.equal(3)
+        if (testStart) {
+          expect(lexResult.tokens[1].startLine).to.equal(1)
+          expect(lexResult.tokens[1].startColumn).to.equal(4)
+        }
+        expect(tokenMatcher(lexResult.tokens[1], LParen)).to.be.true
+
+        expect(lexResult.tokens[2].image).to.equal("666")
+        expect(lexResult.tokens[2].startOffset).to.equal(4)
+        if (testStart) {
+          expect(lexResult.tokens[2].startLine).to.equal(1)
+          expect(lexResult.tokens[2].startColumn).to.equal(5)
+        }
+        expect(tokenMatcher(lexResult.tokens[2], Integer)).to.be.true
+
+        expect(lexResult.tokens[3].image).to.equal(")")
+        expect(lexResult.tokens[3].startOffset).to.equal(7)
+        if (testStart) {
+          expect(lexResult.tokens[3].startLine).to.equal(1)
+          expect(lexResult.tokens[3].startColumn).to.equal(8)
+        }
+        expect(tokenMatcher(lexResult.tokens[3], RParen)).to.be.true
+
+        expect(lexResult.tokens[4].image).to.equal("return")
+        expect(lexResult.tokens[4].startOffset).to.equal(9)
+        if (testStart) {
+          expect(lexResult.tokens[4].startLine).to.equal(1)
+          expect(lexResult.tokens[4].startColumn).to.equal(10)
+        }
+        expect(tokenMatcher(lexResult.tokens[4], Return)).to.be.true
+
+        expect(lexResult.tokens[5].image).to.equal("1")
+        expect(lexResult.tokens[5].startOffset).to.equal(16)
+        if (testStart) {
+          expect(lexResult.tokens[5].startLine).to.equal(1)
+          expect(lexResult.tokens[5].startColumn).to.equal(17)
+        }
+        expect(tokenMatcher(lexResult.tokens[5], Integer)).to.be.true
+      })
+
       it("can deal with line terminators inside multi-line Tokens", () => {
         const ifElseLexer = new Lexer(
           [If, Else, WhitespaceNotSkipped],

--- a/packages/types/api.d.ts
+++ b/packages/types/api.d.ts
@@ -1367,6 +1367,11 @@ export interface ILexerConfig {
    *   - For example: via a conditional that checks an env variable.
    */
   skipValidations?: boolean
+
+  /**
+   * Is the error recovery / fault tolerance of the Chevrotain Lexer enabled.
+   */
+  recoveryEnabled?: boolean
 }
 
 export interface ILexerErrorMessageProvider {


### PR DESCRIPTION
Setting recoveryEnabled to false on an instance of the Lexer class will prevent chevrotain from
trying to consume more characters when it cannot match a token at the current scanning offset

fix #1838

Useful when a token does not match but may match on the next character. For instance I match 'account names' which can optionally be surrounded by parentheses, but can also contain parentheses if not fully surrounded. ex:

'Real' accounts
```
Assets:Chequing
Assets:Joint Chequing
(An)Asset:Chequing
```
'Virtual' accounts
```
(Assets:Chequing)
(Assets:Joint Chequing
((An)Asset:Chequing)
```

Due to the interspersed brackets, it isn't easy to take care of the () in the parser as separate tokens, as I'd have to concatenate the internal parentheses and text segments. In some places I want to ONLY accept a 'real' account, but when the lexer steps forward one char (losing the opening bracket), it will now match. ex:

```
Assets:Chequing <- valid token
(Assets:Chequing) <- invalid token in this lexing mode, BUT:
Assets:Chequing) <- will be matched when it tries to skip the opening parentheses
``` 