### PR TITLE
chore: remove validation for redundant methods

### DIFF
--- a/packages/chevrotain/src/parse/cst/cst_visitor.ts
+++ b/packages/chevrotain/src/parse/cst/cst_visitor.ts
@@ -7,7 +7,6 @@ import filter from "lodash/filter"
 import keys from "lodash/keys"
 import isFunction from "lodash/isFunction"
 import isUndefined from "lodash/isUndefined"
-import includes from "lodash/includes"
 import { defineNameProp } from "../../lang/lang_extensions"
 import { CstNode, ICstVisitor } from "@chevrotain/types"
 
@@ -123,9 +122,8 @@ export function validateVisitor(
   ruleNames: string[]
 ): IVisitorDefinitionError[] {
   const missingErrors = validateMissingCstMethods(visitorInstance, ruleNames)
-  const redundantErrors = validateRedundantMethods(visitorInstance, ruleNames)
 
-  return missingErrors.concat(redundantErrors)
+  return missingErrors
 }
 
 export function validateMissingCstMethods(
@@ -150,34 +148,4 @@ export function validateMissingCstMethods(
   )
 
   return compact<IVisitorDefinitionError>(errors)
-}
-
-const VALID_PROP_NAMES = ["constructor", "visit", "validateVisitor"]
-
-export function validateRedundantMethods(
-  visitorInstance: ICstVisitor<unknown, unknown>,
-  ruleNames: string[]
-): IVisitorDefinitionError[] {
-  const errors: IVisitorDefinitionError[] = []
-  const propNames = Object.getOwnPropertyNames(
-    visitorInstance.constructor.prototype
-  )
-  forEach(propNames, (prop) => {
-    if (
-      isFunction((visitorInstance as any)[prop]) &&
-      !includes(VALID_PROP_NAMES, prop) &&
-      !includes(ruleNames, prop)
-    ) {
-      errors.push({
-        msg:
-          `Redundant visitor method: <${prop}> on ${<any>(
-            visitorInstance.constructor.name
-          )} CST Visitor\n` +
-          `There is no Grammar Rule corresponding to this method's name.\n`,
-        type: CstVisitorDefinitionError.REDUNDANT_METHOD,
-        methodName: prop
-      })
-    }
-  })
-  return errors
 }

--- a/packages/chevrotain/test/parse/cst_visitor_spec.ts
+++ b/packages/chevrotain/test/parse/cst_visitor_spec.ts
@@ -194,26 +194,4 @@ describe("The CSTVisitor", () => {
       "Errors Detected in CST Visitor"
     )
   })
-
-  it("can detect redundant visitor methods", () => {
-    class CstVisitorValidatorRedundant extends BaseVisitor {
-      constructor() {
-        super()
-        this.validateVisitor()
-      }
-
-      testRule(ctx: any, param: any) {}
-
-      bamba(ctx: any, param: any) {}
-
-      oops(ctx: any, param: any) {}
-    }
-
-    expect(() => new CstVisitorValidatorRedundant()).to.throw(
-      "Redundant visitor method: <oops>"
-    )
-    expect(() => new CstVisitorValidatorRedundant()).to.throw(
-      "Errors Detected in CST Visitor"
-    )
-  })
 })

--- a/packages/types/api.d.ts
+++ b/packages/types/api.d.ts
@@ -1909,6 +1909,11 @@ export interface IOrAltWithGate<T> extends IOrAlt<T> {
 
 export interface ICstVisitor<IN, OUT> {
   visit(cstNode: CstNode | CstNode[], param?: IN): OUT
+
+  /**
+   * Will throw an error if the visitor is missing any required methods
+   * - `visitXYZ` for each `XYZ` grammar rule.
+   */
   validateVisitor(): void
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,10 +10,10 @@
       "path": "./packages/gast"
     },
     {
-      "path": "./packages/chevrotain"
+      "path": "./packages/cst-dts-gen"
     },
     {
-      "path": "./packages/cst-dts-gen"
+      "path": "./packages/chevrotain"
     },
     {
       "path": "./packages/cst-dts-gen-test"


### PR DESCRIPTION
This validation was problematic because different
manners of inheritance implementations in js may require
different approaches for enumerating the method names

Additionally this validation did not handle the case of custom
utilities on visitors which resulted in false positives.