### PR TITLE
docs: IRecognitionException should extend 'Error'

### DIFF
--- a/packages/types/api.d.ts
+++ b/packages/types/api.d.ts
@@ -2260,7 +2260,7 @@ export declare const defaultParserErrorProvider: IParserErrorMessageProvider
 /**
  * A Chevrotain Parser runtime exception.
  */
-export interface IRecognitionException {
+export interface IRecognitionException extends Error {
   name: string
   message: string
   /**


### PR DESCRIPTION
`IRecognitionException` doesn't  extend `Error`, so for example
```typescript
parserInstance.errors[0].stack
```
is not recognized by typescript.