### PR TITLE
fix: missing call to lookahead initialization

### DIFF
--- a/packages/chevrotain/src/parse/grammar/llk_lookahead.ts
+++ b/packages/chevrotain/src/parse/grammar/llk_lookahead.ts
@@ -28,9 +28,9 @@ import { IParserDefinitionError } from "./types"
 export class LLkLookaheadStrategy implements ILookaheadStrategy {
   readonly maxLookahead: number
 
-  constructor(options: { maxLookahead?: number }) {
+  constructor(options?: { maxLookahead?: number }) {
     this.maxLookahead =
-      options.maxLookahead ?? DEFAULT_PARSER_CONFIG.maxLookahead
+      options?.maxLookahead ?? DEFAULT_PARSER_CONFIG.maxLookahead
   }
 
   validate(options: {

--- a/packages/chevrotain/src/parse/parser/parser.ts
+++ b/packages/chevrotain/src/parse/parser/parser.ts
@@ -232,6 +232,9 @@ export class Parser {
         }
 
         this.TRACE_INIT("ComputeLookaheadFunctions", () => {
+          this.lookaheadStrategy.initialize?.({
+            rules: values(this.gastProductionsCache)
+          })
           this.preComputeLookaheadFunctions(values(this.gastProductionsCache))
         })
       }

--- a/packages/types/api.d.ts
+++ b/packages/types/api.d.ts
@@ -2152,7 +2152,8 @@ export interface ILLkLookaheadValidator {
  * @experimental
  */
 export interface ILLkLookaheadStrategyConstructor {
-  new (): ILookaheadStrategy & ILLkLookaheadValidator
+  new (options?: { maxLookahead?: number }): ILookaheadStrategy &
+    ILLkLookaheadValidator
 }
 
 /**


### PR DESCRIPTION
1. Fixes the missing call to the lookahead initialization method
2. Adds the `{ maxLookahead: number }` options to the LLk constructor