### PR TITLE
chore: add types at package.json exports

### DIFF
--- a/packages/chevrotain/package.json
+++ b/packages/chevrotain/package.json
@@ -40,6 +40,7 @@
   "typings": "./chevrotain.d.ts",
   "main": "./lib/src/api.js",
   "exports": {
+    "types": "./chevrotain.d.ts",
     "require": "./lib/src/api.js",
     "import": "./lib_esm/api_esm.mjs"
   },


### PR DESCRIPTION
ESM only packages fails to find the types.

A copy of type file is required to make `tsc` succeed:
https://github.com/jhipster/generator-jhipster/blob/main/jdl/chevrotain.d.ts

Reference for package.json exports field:
https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing
```
    "exports": {
        ".": {
            // Entry-point for TypeScript resolution - must occur first!
            "types": "./types/index.d.ts",
            // Entry-point for `import "my-package"` in ESM
            "import": "./esm/index.js",
            // Entry-point for `require("my-package") in CJS
            "require": "./commonjs/index.cjs",
        },
    },
```