### PR TITLE
fix: add skipLibCheck flag to tsconfig

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -9,6 +9,7 @@
     "sourceMap": true,
     "declaration": true,
     "lib": ["es2015", "dom"],
-    "strict": true
+    "strict": true,
+    "skipLibCheck": true
   }
 }


### PR DESCRIPTION
Error occurs when `pnpm run compile` after first project clone
<img width="763" alt="image" src="https://user-images.githubusercontent.com/1837929/216804528-74d8e7e3-ea03-4491-bf7d-163543dbd8cc.png">

skipLibCheck fixed the issue;

Env:
node - v14.16.0
pnpm - 7.26.3
system - mac os