### PR TITLE
feat: add IRecognitionException to recoveryValueFunc arguments to pro…

### DIFF
--- a/packages/chevrotain/src/parse/parser/traits/recognizer_engine.ts
+++ b/packages/chevrotain/src/parse/parser/traits/recognizer_engine.ts
@@ -281,7 +281,7 @@ export class RecognizerEngine {
             partialCstResult.recoveredNode = true
             return partialCstResult
           } else {
-            return recoveryValueFunc()
+            return recoveryValueFunc(e)
           }
         } else {
           if (this.outputCst) {
@@ -298,7 +298,7 @@ export class RecognizerEngine {
         this.moveToTerminatedState()
         // the parser should never throw one of its own errors outside its flow.
         // even if error recovery is disabled
-        return recoveryValueFunc()
+        return recoveryValueFunc(e)
       } else {
         // to be recovered Further up the call stack
         throw recogError

--- a/packages/types/api.d.ts
+++ b/packages/types/api.d.ts
@@ -1757,7 +1757,7 @@ export interface IRuleConfig<T> {
    * The function which will be invoked to produce the returned value for a production that have not been
    * successfully executed and the parser recovered from.
    */
-  recoveryValueFunc?: () => T
+  recoveryValueFunc?: (e: IRecognitionException) => T
   /**
    * Enable/Disable re-sync error recovery for this specific production.
    */


### PR DESCRIPTION
I'm using the EmbeddedActionsParser with recoveryEnabled to generate my own AST nodes.

I want some range information about the recoveryNode to generete the errorNode, but now i've got no place to find the range information.

I hope it'll provide some context information about the error when calling custom recoveryValueFunc.