### PR TITLE
feat: add regexp-to-ast package

### DIFF
--- a/packages/regexp-to-ast/.mocharc.js
+++ b/packages/regexp-to-ast/.mocharc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  recursive: true,
+  reporter: "spec",
+  spec: "./test/**/*spec.js"
+}

--- a/packages/regexp-to-ast/nyc.config.js
+++ b/packages/regexp-to-ast/nyc.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  reporter: ["lcov", "text"],
+  exclude: [
+    "lib/test/**/*.*",
+    "test/test.config.js",
+    // unable to exclude specific deperacted function in this file
+    // due to transpilation step "moving" the ignore comments around.
+    "lib/src/parse/errors_public.js"
+  ]
+}

--- a/packages/regexp-to-ast/package.json
+++ b/packages/regexp-to-ast/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@chevrotain/regexp-to-ast",
+  "version": "0.5.0",
+  "main": "lib/regexp-to-ast.js",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/Chevrotain/chevrotain.git"
+  },
+  "license": "Apache-2.0",
+  "author": {
+    "name": "Shahar Soel"
+  },
+  "description": "Parses a Regular Expression and outputs an AST",
+  "keywords": [
+    "regExp",
+    "parser",
+    "regular expression"
+  ],
+  "dependencies": {},
+  "devDependencies": {
+    "chai": "4.3.7",
+    "eslint": "8.30.0",
+    "eslint-config-prettier": "8.5.0",
+    "eslint-plugin-es5": "^1.4.1",
+    "gitty": "^3.7.0",
+    "mocha": "10.2.0"
+  },
+  "scripts": {
+    "coverage": "nyc mocha"
+  }
+}

--- a/packages/regexp-to-ast/src/regexp-to-ast.js
+++ b/packages/regexp-to-ast/src/regexp-to-ast.js
@@ -1,0 +1,1004 @@
+;(function(root, factory) {
+    // istanbul ignore next
+    if (typeof define === "function" && define.amd) {
+        // istanbul ignore next
+        define([], factory)
+    } else if (typeof module === "object" && module.exports) {
+        module.exports = factory()
+    } else {
+        // istanbul ignore next
+        root.regexpToAst = factory()
+    }
+})(
+    typeof self !== "undefined"
+        ? // istanbul ignore next
+          self
+        : this,
+    function() {
+        // references
+        // https://hackernoon.com/the-madness-of-parsing-real-world-javascript-regexps-d9ee336df983
+        // https://www.ecma-international.org/ecma-262/8.0/index.html#prod-Pattern
+        function RegExpParser() {}
+
+        RegExpParser.prototype.saveState = function() {
+            return {
+                idx: this.idx,
+                input: this.input,
+                groupIdx: this.groupIdx
+            }
+        }
+
+        RegExpParser.prototype.restoreState = function(newState) {
+            this.idx = newState.idx
+            this.input = newState.input
+            this.groupIdx = newState.groupIdx
+        }
+
+        RegExpParser.prototype.pattern = function(input) {
+            // parser state
+            this.idx = 0
+            this.input = input
+            this.groupIdx = 0
+
+            this.consumeChar("/")
+            var value = this.disjunction()
+            this.consumeChar("/")
+
+            var flags = {
+                type: "Flags",
+                loc: { begin: this.idx, end: input.length },
+                global: false,
+                ignoreCase: false,
+                multiLine: false,
+                unicode: false,
+                sticky: false
+            }
+
+            while (this.isRegExpFlag()) {
+                switch (this.popChar()) {
+                    case "g":
+                        addFlag(flags, "global")
+                        break
+                    case "i":
+                        addFlag(flags, "ignoreCase")
+                        break
+                    case "m":
+                        addFlag(flags, "multiLine")
+                        break
+                    case "u":
+                        addFlag(flags, "unicode")
+                        break
+                    case "y":
+                        addFlag(flags, "sticky")
+                        break
+                }
+            }
+
+            if (this.idx !== this.input.length) {
+                throw Error(
+                    "Redundant input: " + this.input.substring(this.idx)
+                )
+            }
+            return {
+                type: "Pattern",
+                flags: flags,
+                value: value,
+                loc: this.loc(0)
+            }
+        }
+
+        RegExpParser.prototype.disjunction = function() {
+            var alts = []
+            var begin = this.idx
+
+            alts.push(this.alternative())
+
+            while (this.peekChar() === "|") {
+                this.consumeChar("|")
+                alts.push(this.alternative())
+            }
+
+            return { type: "Disjunction", value: alts, loc: this.loc(begin) }
+        }
+
+        RegExpParser.prototype.alternative = function() {
+            var terms = []
+            var begin = this.idx
+
+            while (this.isTerm()) {
+                terms.push(this.term())
+            }
+
+            return { type: "Alternative", value: terms, loc: this.loc(begin) }
+        }
+
+        RegExpParser.prototype.term = function() {
+            if (this.isAssertion()) {
+                return this.assertion()
+            } else {
+                return this.atom()
+            }
+        }
+
+        RegExpParser.prototype.assertion = function() {
+            var begin = this.idx
+            switch (this.popChar()) {
+                case "^":
+                    return {
+                        type: "StartAnchor",
+                        loc: this.loc(begin)
+                    }
+                case "$":
+                    return { type: "EndAnchor", loc: this.loc(begin) }
+                // '\b' or '\B'
+                case "\\":
+                    switch (this.popChar()) {
+                        case "b":
+                            return {
+                                type: "WordBoundary",
+                                loc: this.loc(begin)
+                            }
+                        case "B":
+                            return {
+                                type: "NonWordBoundary",
+                                loc: this.loc(begin)
+                            }
+                    }
+                    // istanbul ignore next
+                    throw Error("Invalid Assertion Escape")
+                // '(?=' or '(?!'
+                case "(":
+                    this.consumeChar("?")
+
+                    var type
+                    switch (this.popChar()) {
+                        case "=":
+                            type = "Lookahead"
+                            break
+                        case "!":
+                            type = "NegativeLookahead"
+                            break
+                    }
+                    ASSERT_EXISTS(type)
+
+                    var disjunction = this.disjunction()
+
+                    this.consumeChar(")")
+
+                    return {
+                        type: type,
+                        value: disjunction,
+                        loc: this.loc(begin)
+                    }
+            }
+            // istanbul ignore next
+            ASSERT_NEVER_REACH_HERE()
+        }
+
+        RegExpParser.prototype.quantifier = function(isBacktracking) {
+            var range
+            var begin = this.idx
+            switch (this.popChar()) {
+                case "*":
+                    range = {
+                        atLeast: 0,
+                        atMost: Infinity
+                    }
+                    break
+                case "+":
+                    range = {
+                        atLeast: 1,
+                        atMost: Infinity
+                    }
+                    break
+                case "?":
+                    range = {
+                        atLeast: 0,
+                        atMost: 1
+                    }
+                    break
+                case "{":
+                    var atLeast = this.integerIncludingZero()
+                    switch (this.popChar()) {
+                        case "}":
+                            range = {
+                                atLeast: atLeast,
+                                atMost: atLeast
+                            }
+                            break
+                        case ",":
+                            var atMost
+                            if (this.isDigit()) {
+                                atMost = this.integerIncludingZero()
+                                range = {
+                                    atLeast: atLeast,
+                                    atMost: atMost
+                                }
+                            } else {
+                                range = {
+                                    atLeast: atLeast,
+                                    atMost: Infinity
+                                }
+                            }
+                            this.consumeChar("}")
+                            break
+                    }
+                    // throwing exceptions from "ASSERT_EXISTS" during backtracking
+                    // causes severe performance degradations
+                    if (isBacktracking === true && range === undefined) {
+                        return undefined
+                    }
+                    ASSERT_EXISTS(range)
+                    break
+            }
+
+            // throwing exceptions from "ASSERT_EXISTS" during backtracking
+            // causes severe performance degradations
+            if (isBacktracking === true && range === undefined) {
+                return undefined
+            }
+
+            ASSERT_EXISTS(range)
+
+            if (this.peekChar(0) === "?") {
+                this.consumeChar("?")
+                range.greedy = false
+            } else {
+                range.greedy = true
+            }
+
+            range.type = "Quantifier"
+            range.loc = this.loc(begin)
+            return range
+        }
+
+        RegExpParser.prototype.atom = function() {
+            var atom
+            var begin = this.idx
+            switch (this.peekChar()) {
+                case ".":
+                    atom = this.dotAll()
+                    break
+                case "\\":
+                    atom = this.atomEscape()
+                    break
+                case "[":
+                    atom = this.characterClass()
+                    break
+                case "(":
+                    atom = this.group()
+                    break
+            }
+
+            if (atom === undefined && this.isPatternCharacter()) {
+                atom = this.patternCharacter()
+            }
+
+            ASSERT_EXISTS(atom)
+
+            atom.loc = this.loc(begin)
+
+            if (this.isQuantifier()) {
+                atom.quantifier = this.quantifier()
+            }
+
+            return atom
+        }
+
+        RegExpParser.prototype.dotAll = function() {
+            this.consumeChar(".")
+            return {
+                type: "Set",
+                complement: true,
+                value: [cc("\n"), cc("\r"), cc("\u2028"), cc("\u2029")]
+            }
+        }
+
+        RegExpParser.prototype.atomEscape = function() {
+            this.consumeChar("\\")
+
+            switch (this.peekChar()) {
+                case "1":
+                case "2":
+                case "3":
+                case "4":
+                case "5":
+                case "6":
+                case "7":
+                case "8":
+                case "9":
+                    return this.decimalEscapeAtom()
+                case "d":
+                case "D":
+                case "s":
+                case "S":
+                case "w":
+                case "W":
+                    return this.characterClassEscape()
+                case "f":
+                case "n":
+                case "r":
+                case "t":
+                case "v":
+                    return this.controlEscapeAtom()
+                case "c":
+                    return this.controlLetterEscapeAtom()
+                case "0":
+                    return this.nulCharacterAtom()
+                case "x":
+                    return this.hexEscapeSequenceAtom()
+                case "u":
+                    return this.regExpUnicodeEscapeSequenceAtom()
+                default:
+                    return this.identityEscapeAtom()
+            }
+        }
+
+        RegExpParser.prototype.decimalEscapeAtom = function() {
+            var value = this.positiveInteger()
+
+            return { type: "GroupBackReference", value: value }
+        }
+
+        RegExpParser.prototype.characterClassEscape = function() {
+            var set
+            var complement = false
+            switch (this.popChar()) {
+                case "d":
+                    set = digitsCharCodes
+                    break
+                case "D":
+                    set = digitsCharCodes
+                    complement = true
+                    break
+                case "s":
+                    set = whitespaceCodes
+                    break
+                case "S":
+                    set = whitespaceCodes
+                    complement = true
+                    break
+                case "w":
+                    set = wordCharCodes
+                    break
+                case "W":
+                    set = wordCharCodes
+                    complement = true
+                    break
+            }
+
+            ASSERT_EXISTS(set)
+
+            return { type: "Set", value: set, complement: complement }
+        }
+
+        RegExpParser.prototype.controlEscapeAtom = function() {
+            var escapeCode
+            switch (this.popChar()) {
+                case "f":
+                    escapeCode = cc("\f")
+                    break
+                case "n":
+                    escapeCode = cc("\n")
+                    break
+                case "r":
+                    escapeCode = cc("\r")
+                    break
+                case "t":
+                    escapeCode = cc("\t")
+                    break
+                case "v":
+                    escapeCode = cc("\v")
+                    break
+            }
+            ASSERT_EXISTS(escapeCode)
+
+            return { type: "Character", value: escapeCode }
+        }
+
+        RegExpParser.prototype.controlLetterEscapeAtom = function() {
+            this.consumeChar("c")
+            var letter = this.popChar()
+            if (/[a-zA-Z]/.test(letter) === false) {
+                throw Error("Invalid ")
+            }
+
+            var letterCode = letter.toUpperCase().charCodeAt(0) - 64
+            return { type: "Character", value: letterCode }
+        }
+
+        RegExpParser.prototype.nulCharacterAtom = function() {
+            // TODO implement '[lookahead ∉ DecimalDigit]'
+            // TODO: for the deprecated octal escape sequence
+            this.consumeChar("0")
+            return { type: "Character", value: cc("\0") }
+        }
+
+        RegExpParser.prototype.hexEscapeSequenceAtom = function() {
+            this.consumeChar("x")
+            return this.parseHexDigits(2)
+        }
+
+        RegExpParser.prototype.regExpUnicodeEscapeSequenceAtom = function() {
+            this.consumeChar("u")
+            return this.parseHexDigits(4)
+        }
+
+        RegExpParser.prototype.identityEscapeAtom = function() {
+            // TODO: implement "SourceCharacter but not UnicodeIDContinue"
+            // // http://unicode.org/reports/tr31/#Specific_Character_Adjustments
+            var escapedChar = this.popChar()
+            return { type: "Character", value: cc(escapedChar) }
+        }
+
+        RegExpParser.prototype.classPatternCharacterAtom = function() {
+            switch (this.peekChar()) {
+                // istanbul ignore next
+                case "\n":
+                // istanbul ignore next
+                case "\r":
+                // istanbul ignore next
+                case "\u2028":
+                // istanbul ignore next
+                case "\u2029":
+                // istanbul ignore next
+                case "\\":
+                // istanbul ignore next
+                case "]":
+                    throw Error("TBD")
+                default:
+                    var nextChar = this.popChar()
+                    return { type: "Character", value: cc(nextChar) }
+            }
+        }
+
+        RegExpParser.prototype.characterClass = function() {
+            var set = []
+            var complement = false
+            this.consumeChar("[")
+            if (this.peekChar(0) === "^") {
+                this.consumeChar("^")
+                complement = true
+            }
+
+            while (this.isClassAtom()) {
+                var from = this.classAtom()
+                var isFromSingleChar = from.type === "Character"
+                if (isFromSingleChar && this.isRangeDash()) {
+                    this.consumeChar("-")
+                    var to = this.classAtom()
+                    var isToSingleChar = to.type === "Character"
+
+                    // a range can only be used when both sides are single characters
+                    if (isToSingleChar) {
+                        if (to.value < from.value) {
+                            throw Error("Range out of order in character class")
+                        }
+                        set.push({ from: from.value, to: to.value })
+                    } else {
+                        // literal dash
+                        insertToSet(from.value, set)
+                        set.push(cc("-"))
+                        insertToSet(to.value, set)
+                    }
+                } else {
+                    insertToSet(from.value, set)
+                }
+            }
+
+            this.consumeChar("]")
+
+            return { type: "Set", complement: complement, value: set }
+        }
+
+        RegExpParser.prototype.classAtom = function() {
+            switch (this.peekChar()) {
+                // istanbul ignore next
+                case "]":
+                // istanbul ignore next
+                case "\n":
+                // istanbul ignore next
+                case "\r":
+                // istanbul ignore next
+                case "\u2028":
+                // istanbul ignore next
+                case "\u2029":
+                    throw Error("TBD")
+                case "\\":
+                    return this.classEscape()
+                default:
+                    return this.classPatternCharacterAtom()
+            }
+        }
+
+        RegExpParser.prototype.classEscape = function() {
+            this.consumeChar("\\")
+            switch (this.peekChar()) {
+                // Matches a backspace.
+                // (Not to be confused with \b word boundary outside characterClass)
+                case "b":
+                    this.consumeChar("b")
+                    return { type: "Character", value: cc("\u0008") }
+                case "d":
+                case "D":
+                case "s":
+                case "S":
+                case "w":
+                case "W":
+                    return this.characterClassEscape()
+                case "f":
+                case "n":
+                case "r":
+                case "t":
+                case "v":
+                    return this.controlEscapeAtom()
+                case "c":
+                    return this.controlLetterEscapeAtom()
+                case "0":
+                    return this.nulCharacterAtom()
+                case "x":
+                    return this.hexEscapeSequenceAtom()
+                case "u":
+                    return this.regExpUnicodeEscapeSequenceAtom()
+                default:
+                    return this.identityEscapeAtom()
+            }
+        }
+
+        RegExpParser.prototype.group = function() {
+            var capturing = true
+            this.consumeChar("(")
+            switch (this.peekChar(0)) {
+                case "?":
+                    this.consumeChar("?")
+                    this.consumeChar(":")
+                    capturing = false
+                    break
+                default:
+                    this.groupIdx++
+                    break
+            }
+            var value = this.disjunction()
+            this.consumeChar(")")
+
+            var groupAst = {
+                type: "Group",
+                capturing: capturing,
+                value: value
+            }
+
+            if (capturing) {
+                groupAst.idx = this.groupIdx
+            }
+
+            return groupAst
+        }
+
+        RegExpParser.prototype.positiveInteger = function() {
+            var number = this.popChar()
+
+            // istanbul ignore next - can't ever get here due to previous lookahead checks
+            // still implementing this error checking in case this ever changes.
+            if (decimalPatternNoZero.test(number) === false) {
+                throw Error("Expecting a positive integer")
+            }
+
+            while (decimalPattern.test(this.peekChar(0))) {
+                number += this.popChar()
+            }
+
+            return parseInt(number, 10)
+        }
+
+        RegExpParser.prototype.integerIncludingZero = function() {
+            var number = this.popChar()
+            if (decimalPattern.test(number) === false) {
+                throw Error("Expecting an integer")
+            }
+
+            while (decimalPattern.test(this.peekChar(0))) {
+                number += this.popChar()
+            }
+
+            return parseInt(number, 10)
+        }
+
+        RegExpParser.prototype.patternCharacter = function() {
+            var nextChar = this.popChar()
+            switch (nextChar) {
+                // istanbul ignore next
+                case "\n":
+                // istanbul ignore next
+                case "\r":
+                // istanbul ignore next
+                case "\u2028":
+                // istanbul ignore next
+                case "\u2029":
+                // istanbul ignore next
+                case "^":
+                // istanbul ignore next
+                case "$":
+                // istanbul ignore next
+                case "\\":
+                // istanbul ignore next
+                case ".":
+                // istanbul ignore next
+                case "*":
+                // istanbul ignore next
+                case "+":
+                // istanbul ignore next
+                case "?":
+                // istanbul ignore next
+                case "(":
+                // istanbul ignore next
+                case ")":
+                // istanbul ignore next
+                case "[":
+                // istanbul ignore next
+                case "|":
+                    // istanbul ignore next
+                    throw Error("TBD")
+                default:
+                    return { type: "Character", value: cc(nextChar) }
+            }
+        }
+        RegExpParser.prototype.isRegExpFlag = function() {
+            switch (this.peekChar(0)) {
+                case "g":
+                case "i":
+                case "m":
+                case "u":
+                case "y":
+                    return true
+                default:
+                    return false
+            }
+        }
+
+        RegExpParser.prototype.isRangeDash = function() {
+            return this.peekChar() === "-" && this.isClassAtom(1)
+        }
+
+        RegExpParser.prototype.isDigit = function() {
+            return decimalPattern.test(this.peekChar(0))
+        }
+
+        RegExpParser.prototype.isClassAtom = function(howMuch) {
+            if (howMuch === undefined) {
+                howMuch = 0
+            }
+
+            switch (this.peekChar(howMuch)) {
+                case "]":
+                case "\n":
+                case "\r":
+                case "\u2028":
+                case "\u2029":
+                    return false
+                default:
+                    return true
+            }
+        }
+
+        RegExpParser.prototype.isTerm = function() {
+            return this.isAtom() || this.isAssertion()
+        }
+
+        RegExpParser.prototype.isAtom = function() {
+            if (this.isPatternCharacter()) {
+                return true
+            }
+
+            switch (this.peekChar(0)) {
+                case ".":
+                case "\\": // atomEscape
+                case "[": // characterClass
+                // TODO: isAtom must be called before isAssertion - disambiguate
+                case "(": // group
+                    return true
+                default:
+                    return false
+            }
+        }
+
+        RegExpParser.prototype.isAssertion = function() {
+            switch (this.peekChar(0)) {
+                case "^":
+                case "$":
+                    return true
+                // '\b' or '\B'
+                case "\\":
+                    switch (this.peekChar(1)) {
+                        case "b":
+                        case "B":
+                            return true
+                        default:
+                            return false
+                    }
+                // '(?=' or '(?!'
+                case "(":
+                    return (
+                        this.peekChar(1) === "?" &&
+                        (this.peekChar(2) === "=" || this.peekChar(2) === "!")
+                    )
+                default:
+                    return false
+            }
+        }
+
+        RegExpParser.prototype.isQuantifier = function() {
+            var prevState = this.saveState()
+            try {
+                return this.quantifier(true) !== undefined
+            } catch (e) {
+                return false
+            } finally {
+                this.restoreState(prevState)
+            }
+        }
+
+        RegExpParser.prototype.isPatternCharacter = function() {
+            switch (this.peekChar()) {
+                case "^":
+                case "$":
+                case "\\":
+                case ".":
+                case "*":
+                case "+":
+                case "?":
+                case "(":
+                case ")":
+                case "[":
+                case "|":
+                case "/":
+                case "\n":
+                case "\r":
+                case "\u2028":
+                case "\u2029":
+                    return false
+                default:
+                    return true
+            }
+        }
+
+        RegExpParser.prototype.parseHexDigits = function(howMany) {
+            var hexString = ""
+            for (var i = 0; i < howMany; i++) {
+                var hexChar = this.popChar()
+                if (hexDigitPattern.test(hexChar) === false) {
+                    throw Error("Expecting a HexDecimal digits")
+                }
+                hexString += hexChar
+            }
+            var charCode = parseInt(hexString, 16)
+            return { type: "Character", value: charCode }
+        }
+
+        RegExpParser.prototype.peekChar = function(howMuch) {
+            if (howMuch === undefined) {
+                howMuch = 0
+            }
+            return this.input[this.idx + howMuch]
+        }
+
+        RegExpParser.prototype.popChar = function() {
+            var nextChar = this.peekChar(0)
+            this.consumeChar()
+            return nextChar
+        }
+
+        RegExpParser.prototype.consumeChar = function(char) {
+            if (char !== undefined && this.input[this.idx] !== char) {
+                throw Error(
+                    "Expected: '" +
+                        char +
+                        "' but found: '" +
+                        this.input[this.idx] +
+                        "' at offset: " +
+                        this.idx
+                )
+            }
+
+            if (this.idx >= this.input.length) {
+                throw Error("Unexpected end of input")
+            }
+            this.idx++
+        }
+
+        RegExpParser.prototype.loc = function(begin) {
+            return { begin: begin, end: this.idx }
+        }
+
+        // consts and utilities
+        var hexDigitPattern = /[0-9a-fA-F]/
+        var decimalPattern = /[0-9]/
+        var decimalPatternNoZero = /[1-9]/
+
+        function cc(char) {
+            return char.charCodeAt(0)
+        }
+
+        function insertToSet(item, set) {
+            if (item.length !== undefined) {
+                item.forEach(function(subItem) {
+                    set.push(subItem)
+                })
+            } else {
+                set.push(item)
+            }
+        }
+
+        function addFlag(flagObj, flagKey) {
+            if (flagObj[flagKey] === true) {
+                throw "duplicate flag " + flagKey
+            }
+
+            flagObj[flagKey] = true
+        }
+
+        function ASSERT_EXISTS(obj) {
+            // istanbul ignore next
+            if (obj === undefined) {
+                throw Error("Internal Error - Should never get here!")
+            }
+        }
+
+        // istanbul ignore next
+        function ASSERT_NEVER_REACH_HERE() {
+            throw Error("Internal Error - Should never get here!")
+        }
+
+        var i
+        var digitsCharCodes = []
+        for (i = cc("0"); i <= cc("9"); i++) {
+            digitsCharCodes.push(i)
+        }
+
+        var wordCharCodes = [cc("_")].concat(digitsCharCodes)
+        for (i = cc("a"); i <= cc("z"); i++) {
+            wordCharCodes.push(i)
+        }
+
+        for (i = cc("A"); i <= cc("Z"); i++) {
+            wordCharCodes.push(i)
+        }
+
+        // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#character-classes
+        var whitespaceCodes = [
+            cc(" "),
+            cc("\f"),
+            cc("\n"),
+            cc("\r"),
+            cc("\t"),
+            cc("\v"),
+            cc("\t"),
+            cc("\u00a0"),
+            cc("\u1680"),
+            cc("\u2000"),
+            cc("\u2001"),
+            cc("\u2002"),
+            cc("\u2003"),
+            cc("\u2004"),
+            cc("\u2005"),
+            cc("\u2006"),
+            cc("\u2007"),
+            cc("\u2008"),
+            cc("\u2009"),
+            cc("\u200a"),
+            cc("\u2028"),
+            cc("\u2029"),
+            cc("\u202f"),
+            cc("\u205f"),
+            cc("\u3000"),
+            cc("\ufeff")
+        ]
+
+        function BaseRegExpVisitor() {}
+
+        BaseRegExpVisitor.prototype.visitChildren = function(node) {
+            for (var key in node) {
+                var child = node[key]
+                /* istanbul ignore else */
+                if (node.hasOwnProperty(key)) {
+                    if (child.type !== undefined) {
+                        this.visit(child)
+                    } else if (Array.isArray(child)) {
+                        child.forEach(function(subChild) {
+                            this.visit(subChild)
+                        }, this)
+                    }
+                }
+            }
+        }
+
+        BaseRegExpVisitor.prototype.visit = function(node) {
+            switch (node.type) {
+                case "Pattern":
+                    this.visitPattern(node)
+                    break
+                case "Flags":
+                    this.visitFlags(node)
+                    break
+                case "Disjunction":
+                    this.visitDisjunction(node)
+                    break
+                case "Alternative":
+                    this.visitAlternative(node)
+                    break
+                case "StartAnchor":
+                    this.visitStartAnchor(node)
+                    break
+                case "EndAnchor":
+                    this.visitEndAnchor(node)
+                    break
+                case "WordBoundary":
+                    this.visitWordBoundary(node)
+                    break
+                case "NonWordBoundary":
+                    this.visitNonWordBoundary(node)
+                    break
+                case "Lookahead":
+                    this.visitLookahead(node)
+                    break
+                case "NegativeLookahead":
+                    this.visitNegativeLookahead(node)
+                    break
+                case "Character":
+                    this.visitCharacter(node)
+                    break
+                case "Set":
+                    this.visitSet(node)
+                    break
+                case "Group":
+                    this.visitGroup(node)
+                    break
+                case "GroupBackReference":
+                    this.visitGroupBackReference(node)
+                    break
+                case "Quantifier":
+                    this.visitQuantifier(node)
+                    break
+            }
+
+            this.visitChildren(node)
+        }
+
+        BaseRegExpVisitor.prototype.visitPattern = function(node) {}
+
+        BaseRegExpVisitor.prototype.visitFlags = function(node) {}
+
+        BaseRegExpVisitor.prototype.visitDisjunction = function(node) {}
+
+        BaseRegExpVisitor.prototype.visitAlternative = function(node) {}
+
+        // Assertion
+        BaseRegExpVisitor.prototype.visitStartAnchor = function(node) {}
+
+        BaseRegExpVisitor.prototype.visitEndAnchor = function(node) {}
+
+        BaseRegExpVisitor.prototype.visitWordBoundary = function(node) {}
+
+        BaseRegExpVisitor.prototype.visitNonWordBoundary = function(node) {}
+
+        BaseRegExpVisitor.prototype.visitLookahead = function(node) {}
+
+        BaseRegExpVisitor.prototype.visitNegativeLookahead = function(node) {}
+
+        // atoms
+        BaseRegExpVisitor.prototype.visitCharacter = function(node) {}
+
+        BaseRegExpVisitor.prototype.visitSet = function(node) {}
+
+        BaseRegExpVisitor.prototype.visitGroup = function(node) {}
+
+        BaseRegExpVisitor.prototype.visitGroupBackReference = function(node) {}
+
+        BaseRegExpVisitor.prototype.visitQuantifier = function(node) {}
+
+        return {
+            RegExpParser: RegExpParser,
+            BaseRegExpVisitor: BaseRegExpVisitor,
+            VERSION: "0.5.0"
+        }
+    }
+)

--- a/packages/regexp-to-ast/test/parser.spec.js
+++ b/packages/regexp-to-ast/test/parser.spec.js
@@ -1,0 +1,1619 @@
+const { RegExpParser } = require("../src/regexp-to-ast")
+const { expect } = require("chai")
+
+describe("The RegExp to Ast parser", () => {
+  let parser
+
+  before(() => {
+    parser = new RegExpParser()
+  })
+
+  context("can parse", () => {
+    it("empty regExp", () => {
+      const ast = parser.pattern("/(?:)/")
+      expect(ast).to.deep.equal({
+        type: "Pattern",
+        loc: { begin: 0, end: 6 },
+        flags: {
+          type: "Flags",
+          loc: { begin: 6, end: 6 },
+          global: false,
+          ignoreCase: false,
+          multiLine: false,
+          unicode: false,
+          sticky: false
+        },
+        value: {
+          type: "Disjunction",
+          loc: { begin: 1, end: 5 },
+          value: [
+            {
+              type: "Alternative",
+              loc: { begin: 1, end: 5 },
+              value: [
+                {
+                  type: "Group",
+                  loc: { begin: 1, end: 5 },
+                  capturing: false,
+                  value: {
+                    type: "Disjunction",
+                    loc: { begin: 4, end: 4 },
+                    value: [
+                      {
+                        type: "Alternative",
+                        loc: { begin: 4, end: 4 },
+                        value: []
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      })
+    })
+
+    context("flags", () => {
+      it("global", () => {
+        const ast = parser.pattern("/(?:)/g")
+        expect(ast.flags).to.deep.equal({
+          type: "Flags",
+          loc: { begin: 6, end: 7 },
+
+          global: true,
+          ignoreCase: false,
+          multiLine: false,
+          unicode: false,
+          sticky: false
+        })
+      })
+
+      it("ignoreCase", () => {
+        const ast = parser.pattern("/(?:)/i")
+        expect(ast.flags).to.deep.equal({
+          type: "Flags",
+          loc: { begin: 6, end: 7 },
+
+          global: false,
+          ignoreCase: true,
+          multiLine: false,
+          unicode: false,
+          sticky: false
+        })
+      })
+
+      it("multiLine", () => {
+        const ast = parser.pattern("/(?:)/m")
+        expect(ast.flags).to.deep.equal({
+          type: "Flags",
+          loc: { begin: 6, end: 7 },
+
+          global: false,
+          ignoreCase: false,
+          multiLine: true,
+          unicode: false,
+          sticky: false
+        })
+      })
+
+      it("unicode", () => {
+        const ast = parser.pattern("/(?:)/u")
+        expect(ast.flags).to.deep.equal({
+          type: "Flags",
+          loc: { begin: 6, end: 7 },
+
+          global: false,
+          ignoreCase: false,
+          multiLine: false,
+          unicode: true,
+          sticky: false
+        })
+      })
+
+      it("ignoreCase", () => {
+        const ast = parser.pattern("/(?:)/y")
+        expect(ast.flags).to.deep.equal({
+          type: "Flags",
+          loc: { begin: 6, end: 7 },
+
+          global: false,
+          ignoreCase: false,
+          multiLine: false,
+          unicode: false,
+          sticky: true
+        })
+      })
+
+      it("none", () => {
+        const ast = parser.pattern("/(?:)/")
+        expect(ast.flags).to.deep.equal({
+          type: "Flags",
+          loc: { begin: 6, end: 6 },
+
+          global: false,
+          ignoreCase: false,
+          multiLine: false,
+          unicode: false,
+          sticky: false
+        })
+      })
+
+      it("all", () => {
+        const ast = parser.pattern("/(?:)/gimuy")
+        expect(ast.flags).to.deep.equal({
+          type: "Flags",
+          loc: { begin: 6, end: 11 },
+
+          global: true,
+          ignoreCase: true,
+          multiLine: true,
+          unicode: true,
+          sticky: true
+        })
+      })
+
+      it("duplicates", () => {
+        const parse = () => parser.pattern("/(?:)/gig")
+        expect(parse).to.throw("duplicate flag global")
+      })
+
+      it("unrecognized", () => {
+        const parse = () => parser.pattern("/(?:)/x")
+        expect(parse).to.throw("Redundant input: x")
+      })
+    })
+
+    context("alternatives", () => {
+      it("single", () => {
+        const ast = parser.pattern("/abc/")
+        expect(ast.value).to.deep.equal({
+          type: "Disjunction",
+          loc: { begin: 1, end: 4 },
+          value: [
+            {
+              type: "Alternative",
+              loc: { begin: 1, end: 4 },
+              value: [
+                {
+                  type: "Character",
+                  loc: { begin: 1, end: 2 },
+                  value: 97
+                },
+                {
+                  type: "Character",
+                  loc: { begin: 2, end: 3 },
+                  value: 98
+                },
+                {
+                  type: "Character",
+                  loc: { begin: 3, end: 4 },
+                  value: 99
+                }
+              ]
+            }
+          ]
+        })
+      })
+
+      it("multiple", () => {
+        const ast = parser.pattern("/a|b|c/")
+        expect(ast.value).to.deep.equal({
+          type: "Disjunction",
+          loc: { begin: 1, end: 6 },
+          value: [
+            {
+              loc: { begin: 1, end: 2 },
+              type: "Alternative",
+              value: [
+                {
+                  type: "Character",
+                  loc: { begin: 1, end: 2 },
+                  value: 97
+                }
+              ]
+            },
+            {
+              type: "Alternative",
+              loc: { begin: 3, end: 4 },
+              value: [
+                {
+                  type: "Character",
+                  loc: { begin: 3, end: 4 },
+                  value: 98
+                }
+              ]
+            },
+            {
+              type: "Alternative",
+              loc: { begin: 5, end: 6 },
+              value: [
+                {
+                  loc: { begin: 5, end: 6 },
+                  type: "Character",
+                  value: 99
+                }
+              ]
+            }
+          ]
+        })
+      })
+
+      it("empty alternative", () => {
+        const ast = parser.pattern("/a||c/")
+        expect(ast.value).to.deep.equal({
+          type: "Disjunction",
+          loc: { begin: 1, end: 5 },
+          value: [
+            {
+              type: "Alternative",
+              loc: { begin: 1, end: 2 },
+              value: [
+                {
+                  type: "Character",
+                  loc: { begin: 1, end: 2 },
+                  value: 97
+                }
+              ]
+            },
+            {
+              type: "Alternative",
+              loc: { begin: 3, end: 3 },
+              value: []
+            },
+            {
+              type: "Alternative",
+              loc: { begin: 4, end: 5 },
+              value: [
+                {
+                  loc: { begin: 4, end: 5 },
+                  type: "Character",
+                  value: 99
+                }
+              ]
+            }
+          ]
+        })
+      })
+    })
+
+    context("assertions", () => {
+      it("startAnchor", () => {
+        const ast = parser.pattern("/^a/")
+        expect(ast.value).to.deep.equal({
+          type: "Disjunction",
+          loc: { begin: 1, end: 3 },
+          value: [
+            {
+              type: "Alternative",
+              loc: { begin: 1, end: 3 },
+              value: [
+                {
+                  type: "StartAnchor",
+                  loc: { begin: 1, end: 2 }
+                },
+                {
+                  type: "Character",
+                  loc: { begin: 2, end: 3 },
+                  value: 97
+                }
+              ]
+            }
+          ]
+        })
+      })
+
+      it("endAnchor", () => {
+        const ast = parser.pattern("/a$/")
+        expect(ast.value).to.deep.equal({
+          type: "Disjunction",
+          loc: { begin: 1, end: 3 },
+          value: [
+            {
+              type: "Alternative",
+              loc: { begin: 1, end: 3 },
+              value: [
+                {
+                  type: "Character",
+                  loc: { begin: 1, end: 2 },
+                  value: 97
+                },
+                {
+                  type: "EndAnchor",
+                  loc: { begin: 2, end: 3 }
+                }
+              ]
+            }
+          ]
+        })
+      })
+
+      it("word boundary", () => {
+        const ast = parser.pattern("/a\\b/")
+        expect(ast.value).to.deep.equal({
+          type: "Disjunction",
+          loc: { begin: 1, end: 4 },
+          value: [
+            {
+              loc: { begin: 1, end: 4 },
+              type: "Alternative",
+              value: [
+                {
+                  loc: { begin: 1, end: 2 },
+                  type: "Character",
+                  value: 97
+                },
+                {
+                  type: "WordBoundary",
+                  loc: { begin: 2, end: 4 }
+                }
+              ]
+            }
+          ]
+        })
+      })
+
+      it("NonWord boundary", () => {
+        const ast = parser.pattern("/a\\B/")
+        expect(ast.value).to.deep.equal({
+          type: "Disjunction",
+          loc: { begin: 1, end: 4 },
+          value: [
+            {
+              type: "Alternative",
+              loc: { begin: 1, end: 4 },
+              value: [
+                {
+                  type: "Character",
+                  loc: { begin: 1, end: 2 },
+                  value: 97
+                },
+                {
+                  type: "NonWordBoundary",
+                  loc: { begin: 2, end: 4 }
+                }
+              ]
+            }
+          ]
+        })
+      })
+
+      it("lookahead assertion", () => {
+        const ast = parser.pattern("/a(?=b)/")
+        expect(ast.value).to.deep.equal({
+          type: "Disjunction",
+          loc: { begin: 1, end: 7 },
+          value: [
+            {
+              type: "Alternative",
+              loc: { begin: 1, end: 7 },
+              value: [
+                {
+                  type: "Character",
+                  loc: { begin: 1, end: 2 },
+                  value: 97
+                },
+                {
+                  type: "Lookahead",
+                  loc: { begin: 2, end: 7 },
+                  value: {
+                    type: "Disjunction",
+                    loc: { begin: 5, end: 6 },
+                    value: [
+                      {
+                        type: "Alternative",
+                        loc: { begin: 5, end: 6 },
+                        value: [
+                          {
+                            type: "Character",
+                            loc: {
+                              begin: 5,
+                              end: 6
+                            },
+                            value: 98
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          ]
+        })
+      })
+
+      it("lookahead assertion", () => {
+        const ast = parser.pattern("/a(?!b)/")
+        expect(ast.value).to.deep.equal({
+          type: "Disjunction",
+          loc: { begin: 1, end: 7 },
+          value: [
+            {
+              type: "Alternative",
+              loc: { begin: 1, end: 7 },
+              value: [
+                {
+                  type: "Character",
+                  loc: { begin: 1, end: 2 },
+                  value: 97
+                },
+                {
+                  type: "NegativeLookahead",
+                  loc: { begin: 2, end: 7 },
+                  value: {
+                    type: "Disjunction",
+                    loc: { begin: 5, end: 6 },
+                    value: [
+                      {
+                        type: "Alternative",
+                        loc: { begin: 5, end: 6 },
+                        value: [
+                          {
+                            type: "Character",
+                            loc: {
+                              begin: 5,
+                              end: 6
+                            },
+                            value: 98
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          ]
+        })
+      })
+    })
+
+    context("quantifiers", () => {
+      it("zero or one", () => {
+        const ast = parser.pattern("/a?/")
+        expect(ast.value).to.deep.equal({
+          type: "Disjunction",
+          loc: { begin: 1, end: 3 },
+          value: [
+            {
+              type: "Alternative",
+              loc: { begin: 1, end: 3 },
+              value: [
+                {
+                  type: "Character",
+                  loc: { begin: 1, end: 2 },
+                  value: 97,
+                  quantifier: {
+                    type: "Quantifier",
+                    loc: { begin: 2, end: 3 },
+                    atLeast: 0,
+                    atMost: 1,
+                    greedy: true
+                  }
+                }
+              ]
+            }
+          ]
+        })
+      })
+
+      it("star", () => {
+        const ast = parser.pattern("/a*/")
+        expect(ast.value).to.deep.equal({
+          type: "Disjunction",
+          loc: { begin: 1, end: 3 },
+          value: [
+            {
+              type: "Alternative",
+              loc: { begin: 1, end: 3 },
+              value: [
+                {
+                  type: "Character",
+                  loc: { begin: 1, end: 2 },
+                  value: 97,
+                  quantifier: {
+                    type: "Quantifier",
+                    loc: { begin: 2, end: 3 },
+                    atLeast: 0,
+                    atMost: Infinity,
+                    greedy: true
+                  }
+                }
+              ]
+            }
+          ]
+        })
+      })
+
+      it("plus", () => {
+        const ast = parser.pattern("/a+/")
+        expect(ast.value).to.deep.equal({
+          type: "Disjunction",
+          loc: { begin: 1, end: 3 },
+          value: [
+            {
+              type: "Alternative",
+              loc: { begin: 1, end: 3 },
+              value: [
+                {
+                  type: "Character",
+                  loc: { begin: 1, end: 2 },
+                  value: 97,
+                  quantifier: {
+                    type: "Quantifier",
+                    loc: { begin: 2, end: 3 },
+                    atLeast: 1,
+                    atMost: Infinity,
+                    greedy: true
+                  }
+                }
+              ]
+            }
+          ]
+        })
+      })
+
+      it("invalid exactlyX", () => {
+        const ast = parser.pattern("/a{b}/")
+        expect(ast.value).to.deep.equal({
+          type: "Disjunction",
+          loc: { begin: 1, end: 5 },
+          value: [
+            {
+              type: "Alternative",
+              loc: { begin: 1, end: 5 },
+              value: [
+                {
+                  type: "Character",
+                  loc: { begin: 1, end: 2 },
+                  value: 97
+                },
+                {
+                  type: "Character",
+                  loc: { begin: 2, end: 3 },
+                  value: 123
+                },
+                {
+                  type: "Character",
+                  loc: { begin: 3, end: 4 },
+                  value: 98
+                },
+                {
+                  type: "Character",
+                  loc: { begin: 4, end: 5 },
+                  value: 125
+                }
+              ]
+            }
+          ]
+        })
+      })
+
+      it("exactlyX", () => {
+        const ast = parser.pattern("/a{6}/")
+        expect(ast.value).to.deep.equal({
+          type: "Disjunction",
+          loc: { begin: 1, end: 5 },
+          value: [
+            {
+              type: "Alternative",
+              loc: { begin: 1, end: 5 },
+              value: [
+                {
+                  type: "Character",
+                  loc: { begin: 1, end: 2 },
+                  value: 97,
+                  quantifier: {
+                    type: "Quantifier",
+                    loc: { begin: 2, end: 5 },
+                    atLeast: 6,
+                    atMost: 6,
+                    greedy: true
+                  }
+                }
+              ]
+            }
+          ]
+        })
+      })
+
+      it("atLeastX", () => {
+        const ast = parser.pattern("/a{2,}/")
+        expect(ast.value).to.deep.equal({
+          type: "Disjunction",
+          loc: { begin: 1, end: 6 },
+          value: [
+            {
+              type: "Alternative",
+              loc: { begin: 1, end: 6 },
+              value: [
+                {
+                  type: "Character",
+                  loc: { begin: 1, end: 2 },
+                  value: 97,
+                  quantifier: {
+                    type: "Quantifier",
+                    loc: { begin: 2, end: 6 },
+                    atLeast: 2,
+                    atMost: Infinity,
+                    greedy: true
+                  }
+                }
+              ]
+            }
+          ]
+        })
+      })
+
+      it("atLeastXAtMostY", () => {
+        const ast = parser.pattern("/a{8,12}/")
+        expect(ast.value).to.deep.equal({
+          type: "Disjunction",
+          loc: { begin: 1, end: 8 },
+          value: [
+            {
+              type: "Alternative",
+              loc: { begin: 1, end: 8 },
+              value: [
+                {
+                  type: "Character",
+                  loc: { begin: 1, end: 2 },
+                  value: 97,
+                  quantifier: {
+                    type: "Quantifier",
+                    loc: { begin: 2, end: 8 },
+                    atLeast: 8,
+                    atMost: 12,
+                    greedy: true
+                  }
+                }
+              ]
+            }
+          ]
+        })
+      })
+
+      it("issue #6 bug", () => {
+        const ast = parser.pattern("/a{0,3}/")
+        expect(ast.value).to.deep.equal({
+          type: "Disjunction",
+          loc: { begin: 1, end: 7 },
+          value: [
+            {
+              type: "Alternative",
+              loc: { begin: 1, end: 7 },
+              value: [
+                {
+                  type: "Character",
+                  loc: { begin: 1, end: 2 },
+                  value: 97,
+                  quantifier: {
+                    type: "Quantifier",
+                    loc: { begin: 2, end: 7 },
+                    atLeast: 0,
+                    atMost: 3,
+                    greedy: true
+                  }
+                }
+              ]
+            }
+          ]
+        })
+      })
+
+      // /[0-9]+[a-z]{0,3}/
+      it("nonGreedy", () => {
+        const ast = parser.pattern("/a??/")
+        expect(ast.value).to.deep.equal({
+          type: "Disjunction",
+          loc: { begin: 1, end: 4 },
+          value: [
+            {
+              type: "Alternative",
+              loc: { begin: 1, end: 4 },
+              value: [
+                {
+                  type: "Character",
+                  loc: { begin: 1, end: 2 },
+                  value: 97,
+                  quantifier: {
+                    type: "Quantifier",
+                    loc: { begin: 2, end: 4 },
+                    atLeast: 0,
+                    atMost: 1,
+                    greedy: false
+                  }
+                }
+              ]
+            }
+          ]
+        })
+      })
+    })
+
+    context("atoms", () => {
+      it("Looks like Quantifier", () => {
+        const ast = parser.pattern("/{{1/")
+        expect(ast.value).to.deep.equal({
+          type: "Disjunction",
+          loc: { begin: 1, end: 4 },
+          value: [
+            {
+              type: "Alternative",
+              loc: { begin: 1, end: 4 },
+              value: [
+                {
+                  type: "Character",
+                  loc: { begin: 1, end: 2 },
+                  value: 123
+                },
+                {
+                  type: "Character",
+                  loc: { begin: 2, end: 3 },
+                  value: 123
+                },
+                {
+                  type: "Character",
+                  loc: { begin: 3, end: 4 },
+                  value: 49
+                }
+              ]
+            }
+          ]
+        })
+      })
+
+      it("patternCharacter", () => {
+        const ast = parser.pattern("/b/")
+        expect(ast.value).to.deep.equal({
+          type: "Disjunction",
+          loc: { begin: 1, end: 2 },
+          value: [
+            {
+              type: "Alternative",
+              loc: { begin: 1, end: 2 },
+              value: [
+                {
+                  type: "Character",
+                  loc: { begin: 1, end: 2 },
+                  value: 98
+                }
+              ]
+            }
+          ]
+        })
+      })
+
+      it("dotAll", () => {
+        const ast = parser.pattern("/./")
+        expect(ast.value).to.deep.equal({
+          type: "Disjunction",
+          loc: { begin: 1, end: 2 },
+          value: [
+            {
+              type: "Alternative",
+              loc: { begin: 1, end: 2 },
+              value: [
+                {
+                  type: "Set",
+                  loc: { begin: 1, end: 2 },
+                  complement: true,
+                  value: [10, 13, 8232, 8233]
+                }
+              ]
+            }
+          ]
+        })
+      })
+
+      context("escapes", () => {
+        context("Character class escapes", () => {
+          it("digit", () => {
+            const ast = parser.pattern("/\\d/")
+            expect(ast.value).to.deep.equal({
+              type: "Disjunction",
+              loc: { begin: 1, end: 3 },
+              value: [
+                {
+                  type: "Alternative",
+                  loc: { begin: 1, end: 3 },
+                  value: [
+                    {
+                      type: "Set",
+                      loc: { begin: 1, end: 3 },
+                      value: [48, 49, 50, 51, 52, 53, 54, 55, 56, 57],
+                      complement: false
+                    }
+                  ]
+                }
+              ]
+            })
+          })
+
+          it("not digit", () => {
+            const ast = parser.pattern("/\\D/")
+            expect(ast.value).to.deep.equal({
+              type: "Disjunction",
+              loc: { begin: 1, end: 3 },
+              value: [
+                {
+                  type: "Alternative",
+                  loc: { begin: 1, end: 3 },
+                  value: [
+                    {
+                      type: "Set",
+                      loc: { begin: 1, end: 3 },
+                      value: [48, 49, 50, 51, 52, 53, 54, 55, 56, 57],
+                      complement: true
+                    }
+                  ]
+                }
+              ]
+            })
+          })
+
+          it("word character", () => {
+            const ast = parser.pattern("/\\w/")
+            expect(ast.value).to.deep.equal({
+              type: "Disjunction",
+              loc: { begin: 1, end: 3 },
+              value: [
+                {
+                  type: "Alternative",
+                  loc: { begin: 1, end: 3 },
+                  value: [
+                    {
+                      type: "Set",
+                      loc: { begin: 1, end: 3 },
+                      value: [
+                        95, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 97, 98, 99,
+                        100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110,
+                        111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121,
+                        122, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77,
+                        78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90
+                      ],
+                      complement: false
+                    }
+                  ]
+                }
+              ]
+            })
+          })
+
+          it("not word character", () => {
+            const ast = parser.pattern("/\\W/")
+            expect(ast.value).to.deep.equal({
+              type: "Disjunction",
+              loc: { begin: 1, end: 3 },
+              value: [
+                {
+                  type: "Alternative",
+                  loc: { begin: 1, end: 3 },
+                  value: [
+                    {
+                      type: "Set",
+                      loc: { begin: 1, end: 3 },
+                      value: [
+                        95, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 97, 98, 99,
+                        100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110,
+                        111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121,
+                        122, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77,
+                        78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90
+                      ],
+                      complement: true
+                    }
+                  ]
+                }
+              ]
+            })
+          })
+
+          it("whitespace", () => {
+            const ast = parser.pattern("/\\s/")
+            expect(ast.value).to.deep.equal({
+              type: "Disjunction",
+              loc: { begin: 1, end: 3 },
+              value: [
+                {
+                  type: "Alternative",
+                  loc: { begin: 1, end: 3 },
+                  value: [
+                    {
+                      type: "Set",
+                      loc: { begin: 1, end: 3 },
+                      value: [
+                        32, 12, 10, 13, 9, 11, 9, 160, 5760, 8192, 8193, 8194,
+                        8195, 8196, 8197, 8198, 8199, 8200, 8201, 8202, 8232,
+                        8233, 8239, 8287, 12288, 65279
+                      ],
+                      complement: false
+                    }
+                  ]
+                }
+              ]
+            })
+          })
+
+          it("not whitespace", () => {
+            const ast = parser.pattern("/\\S/")
+            expect(ast.value).to.deep.equal({
+              type: "Disjunction",
+              loc: { begin: 1, end: 3 },
+              value: [
+                {
+                  type: "Alternative",
+                  loc: { begin: 1, end: 3 },
+                  value: [
+                    {
+                      type: "Set",
+                      loc: { begin: 1, end: 3 },
+                      value: [
+                        32, 12, 10, 13, 9, 11, 9, 160, 5760, 8192, 8193, 8194,
+                        8195, 8196, 8197, 8198, 8199, 8200, 8201, 8202, 8232,
+                        8233, 8239, 8287, 12288, 65279
+                      ],
+                      complement: true
+                    }
+                  ]
+                }
+              ]
+            })
+          })
+        })
+
+        context("decimal", () => {
+          it("valid escape", () => {
+            const ast = parser.pattern("/\\123/")
+            expect(ast.value).to.deep.equal({
+              type: "Disjunction",
+              loc: { begin: 1, end: 5 },
+              value: [
+                {
+                  type: "Alternative",
+                  loc: { begin: 1, end: 5 },
+                  value: [
+                    {
+                      type: "GroupBackReference",
+                      loc: { begin: 1, end: 5 },
+                      value: 123
+                    }
+                  ]
+                }
+              ]
+            })
+          })
+        })
+
+        context("control escape", () => {
+          it("form feed", () => {
+            const ast = parser.pattern("/\\f/")
+            expect(ast.value).to.deep.equal({
+              type: "Disjunction",
+              loc: { begin: 1, end: 3 },
+              value: [
+                {
+                  type: "Alternative",
+                  loc: { begin: 1, end: 3 },
+                  value: [
+                    {
+                      type: "Character",
+                      loc: { begin: 1, end: 3 },
+                      value: 12
+                    }
+                  ]
+                }
+              ]
+            })
+          })
+
+          it("new line", () => {
+            const ast = parser.pattern("/\\n/")
+            expect(ast.value).to.deep.equal({
+              type: "Disjunction",
+              loc: { begin: 1, end: 3 },
+              value: [
+                {
+                  type: "Alternative",
+                  loc: { begin: 1, end: 3 },
+                  value: [
+                    {
+                      type: "Character",
+                      loc: { begin: 1, end: 3 },
+                      value: 10
+                    }
+                  ]
+                }
+              ]
+            })
+          })
+
+          it("carriage return", () => {
+            const ast = parser.pattern("/\\r/")
+            expect(ast.value).to.deep.equal({
+              type: "Disjunction",
+              loc: { begin: 1, end: 3 },
+              value: [
+                {
+                  type: "Alternative",
+                  loc: { begin: 1, end: 3 },
+                  value: [
+                    {
+                      type: "Character",
+                      loc: { begin: 1, end: 3 },
+                      value: 13
+                    }
+                  ]
+                }
+              ]
+            })
+          })
+
+          it("horizontal tab", () => {
+            const ast = parser.pattern("/\\t/")
+            expect(ast.value).to.deep.equal({
+              type: "Disjunction",
+              loc: { begin: 1, end: 3 },
+              value: [
+                {
+                  type: "Alternative",
+                  loc: { begin: 1, end: 3 },
+                  value: [
+                    {
+                      type: "Character",
+                      loc: { begin: 1, end: 3 },
+                      value: 9
+                    }
+                  ]
+                }
+              ]
+            })
+          })
+
+          it("vertical tab", () => {
+            const ast = parser.pattern("/\\v/")
+            expect(ast.value).to.deep.equal({
+              type: "Disjunction",
+              loc: { begin: 1, end: 3 },
+              value: [
+                {
+                  type: "Alternative",
+                  loc: { begin: 1, end: 3 },
+                  value: [
+                    {
+                      type: "Character",
+                      loc: { begin: 1, end: 3 },
+                      value: 11
+                    }
+                  ]
+                }
+              ]
+            })
+          })
+        })
+
+        it("control letter", () => {
+          const ast = parser.pattern("/\\cB/")
+          expect(ast.value).to.deep.equal({
+            type: "Disjunction",
+            loc: { begin: 1, end: 4 },
+            value: [
+              {
+                type: "Alternative",
+                loc: { begin: 1, end: 4 },
+                value: [
+                  {
+                    type: "Character",
+                    loc: { begin: 1, end: 4 },
+                    value: 2
+                  }
+                ]
+              }
+            ]
+          })
+        })
+
+        it("invalid control letter", () => {
+          expect(() => parser.pattern("/\\c9/")).to.throw()
+        })
+
+        it("nul character", () => {
+          const ast = parser.pattern("/\\0/")
+          expect(ast.value).to.deep.equal({
+            type: "Disjunction",
+            loc: { begin: 1, end: 3 },
+            value: [
+              {
+                type: "Alternative",
+                loc: { begin: 1, end: 3 },
+                value: [
+                  {
+                    type: "Character",
+                    loc: { begin: 1, end: 3 },
+                    value: 0
+                  }
+                ]
+              }
+            ]
+          })
+        })
+
+        it("invalid hex", () => {
+          expect(() => parser.pattern("/\\x2v/")).to.throw(
+            "Expecting a HexDecimal digits"
+          )
+        })
+
+        it("unicode", () => {
+          const ast = parser.pattern("/\\u000a/")
+          expect(ast.value).to.deep.equal({
+            type: "Disjunction",
+            loc: { begin: 1, end: 7 },
+            value: [
+              {
+                type: "Alternative",
+                loc: { begin: 1, end: 7 },
+                value: [
+                  {
+                    type: "Character",
+                    loc: { begin: 1, end: 7 },
+                    value: 10
+                  }
+                ]
+              }
+            ]
+          })
+        })
+
+        it("Identity", () => {
+          const ast = parser.pattern("/\\*/")
+          expect(ast.value).to.deep.equal({
+            type: "Disjunction",
+            loc: { begin: 1, end: 3 },
+            value: [
+              {
+                type: "Alternative",
+                loc: { begin: 1, end: 3 },
+                value: [
+                  {
+                    type: "Character",
+                    loc: { begin: 1, end: 3 },
+                    value: 42
+                  }
+                ]
+              }
+            ]
+          })
+        })
+      })
+
+      context("CharacterClass", () => {
+        context("escapes", () => {
+          it("closing square parenthesis", () => {
+            const ast = parser.pattern("/[\\]]/")
+            expect(ast.value).to.deep.equal({
+              type: "Disjunction",
+              loc: { begin: 1, end: 5 },
+              value: [
+                {
+                  type: "Alternative",
+                  loc: { begin: 1, end: 5 },
+                  value: [
+                    {
+                      type: "Set",
+                      loc: { begin: 1, end: 5 },
+                      complement: false,
+                      value: [93]
+                    }
+                  ]
+                }
+              ]
+            })
+          })
+
+          it("backspace", () => {
+            const ast = parser.pattern("/[\\b]/")
+            expect(ast.value).to.deep.equal({
+              type: "Disjunction",
+              loc: { begin: 1, end: 5 },
+              value: [
+                {
+                  type: "Alternative",
+                  loc: { begin: 1, end: 5 },
+                  value: [
+                    {
+                      type: "Set",
+                      loc: { begin: 1, end: 5 },
+                      complement: false,
+                      value: [8]
+                    }
+                  ]
+                }
+              ]
+            })
+          })
+
+          it("form feed", () => {
+            const ast = parser.pattern("/[\\f]/")
+            expect(ast.value).to.deep.equal({
+              type: "Disjunction",
+              loc: { begin: 1, end: 5 },
+              value: [
+                {
+                  type: "Alternative",
+                  loc: { begin: 1, end: 5 },
+                  value: [
+                    {
+                      type: "Set",
+                      loc: { begin: 1, end: 5 },
+                      complement: false,
+                      value: [12]
+                    }
+                  ]
+                }
+              ]
+            })
+          })
+
+          it("control letter", () => {
+            const ast = parser.pattern("/[\\cd]/")
+            expect(ast.value).to.deep.equal({
+              type: "Disjunction",
+              loc: { begin: 1, end: 6 },
+              value: [
+                {
+                  type: "Alternative",
+                  loc: { begin: 1, end: 6 },
+                  value: [
+                    {
+                      complement: false,
+                      type: "Set",
+                      loc: { begin: 1, end: 6 },
+                      value: [4]
+                    }
+                  ]
+                }
+              ]
+            })
+          })
+
+          it("nul", () => {
+            const ast = parser.pattern("/[\\0a]/")
+            expect(ast.value).to.deep.equal({
+              type: "Disjunction",
+              loc: { begin: 1, end: 6 },
+              value: [
+                {
+                  type: "Alternative",
+                  loc: { begin: 1, end: 6 },
+                  value: [
+                    {
+                      type: "Set",
+                      loc: { begin: 1, end: 6 },
+                      complement: false,
+                      value: [0, 97]
+                    }
+                  ]
+                }
+              ]
+            })
+          })
+
+          it("hexDecimal", () => {
+            const ast = parser.pattern("/[\\xbc]/")
+            expect(ast.value).to.deep.equal({
+              type: "Disjunction",
+              loc: { begin: 1, end: 7 },
+              value: [
+                {
+                  type: "Alternative",
+                  loc: { begin: 1, end: 7 },
+                  value: [
+                    {
+                      type: "Set",
+                      loc: { begin: 1, end: 7 },
+                      complement: false,
+                      value: [188]
+                    }
+                  ]
+                }
+              ]
+            })
+          })
+
+          it("unicode", () => {
+            const ast = parser.pattern("/[\\u001a]/")
+            expect(ast.value).to.deep.equal({
+              type: "Disjunction",
+              loc: { begin: 1, end: 9 },
+              value: [
+                {
+                  type: "Alternative",
+                  loc: { begin: 1, end: 9 },
+                  value: [
+                    {
+                      complement: false,
+                      type: "Set",
+                      loc: { begin: 1, end: 9 },
+                      value: [26]
+                    }
+                  ]
+                }
+              ]
+            })
+          })
+
+          it("digits", () => {
+            const ast = parser.pattern("/[\\d]/")
+            expect(ast.value).to.deep.equal({
+              type: "Disjunction",
+              loc: { begin: 1, end: 5 },
+              value: [
+                {
+                  type: "Alternative",
+                  loc: { begin: 1, end: 5 },
+                  value: [
+                    {
+                      type: "Set",
+                      loc: { begin: 1, end: 5 },
+                      complement: false,
+                      value: [48, 49, 50, 51, 52, 53, 54, 55, 56, 57]
+                    }
+                  ]
+                }
+              ]
+            })
+          })
+        })
+
+        it("pattern character", () => {
+          const ast = parser.pattern("/[a]/")
+          expect(ast.value).to.deep.equal({
+            type: "Disjunction",
+            loc: { begin: 1, end: 4 },
+            value: [
+              {
+                type: "Alternative",
+                loc: { begin: 1, end: 4 },
+                value: [
+                  {
+                    type: "Set",
+                    loc: { begin: 1, end: 4 },
+                    complement: false,
+                    value: [97]
+                  }
+                ]
+              }
+            ]
+          })
+        })
+
+        it("complement", () => {
+          const ast = parser.pattern("/[^a]/")
+          expect(ast.value).to.deep.equal({
+            type: "Disjunction",
+            loc: { begin: 1, end: 5 },
+            value: [
+              {
+                type: "Alternative",
+                loc: { begin: 1, end: 5 },
+                value: [
+                  {
+                    type: "Set",
+                    loc: { begin: 1, end: 5 },
+                    complement: true,
+                    value: [97]
+                  }
+                ]
+              }
+            ]
+          })
+        })
+
+        it("range", () => {
+          const ast = parser.pattern("/[A-Z]/")
+          expect(ast.value).to.deep.equal({
+            type: "Disjunction",
+            loc: { begin: 1, end: 6 },
+            value: [
+              {
+                type: "Alternative",
+                loc: { begin: 1, end: 6 },
+                value: [
+                  {
+                    type: "Set",
+                    loc: { begin: 1, end: 6 },
+                    complement: false,
+                    value: [
+                      {
+                        from: 65,
+                        to: 90
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          })
+        })
+
+        it("invalid range", () => {
+          expect(() => parser.pattern("/[B-A]/")).to.throw(
+            "Range out of order in character class"
+          )
+        })
+
+        it("range with set", () => {
+          const ast = parser.pattern("/[A-\\d]/")
+          expect(ast.value).to.deep.equal({
+            type: "Disjunction",
+            loc: { begin: 1, end: 7 },
+            value: [
+              {
+                type: "Alternative",
+                loc: { begin: 1, end: 7 },
+                value: [
+                  {
+                    type: "Set",
+                    loc: { begin: 1, end: 7 },
+                    complement: false,
+                    value: [65, 45, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57]
+                  }
+                ]
+              }
+            ]
+          })
+        })
+      })
+    })
+
+    context("groups", () => {
+      it("capturing", () => {
+        const ast = parser.pattern("/(a)(b)/")
+        expect(ast.value).to.deep.equal({
+          type: "Disjunction",
+          loc: { begin: 1, end: 7 },
+          value: [
+            {
+              type: "Alternative",
+              loc: { begin: 1, end: 7 },
+              value: [
+                {
+                  type: "Group",
+                  loc: { begin: 1, end: 4 },
+                  capturing: true,
+                  value: {
+                    type: "Disjunction",
+                    loc: { begin: 2, end: 3 },
+                    value: [
+                      {
+                        type: "Alternative",
+                        loc: { begin: 2, end: 3 },
+                        value: [
+                          {
+                            type: "Character",
+                            loc: {
+                              begin: 2,
+                              end: 3
+                            },
+                            value: 97
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  idx: 1
+                },
+                {
+                  type: "Group",
+                  loc: { begin: 4, end: 7 },
+                  capturing: true,
+                  value: {
+                    type: "Disjunction",
+                    loc: { begin: 5, end: 6 },
+                    value: [
+                      {
+                        type: "Alternative",
+                        loc: { begin: 5, end: 6 },
+                        value: [
+                          {
+                            type: "Character",
+                            loc: {
+                              begin: 5,
+                              end: 6
+                            },
+                            value: 98
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  idx: 2
+                }
+              ]
+            }
+          ]
+        })
+      })
+
+      it("non capturing", () => {
+        const ast = parser.pattern("/(?:a)(b)/")
+        expect(ast.value).to.deep.equal({
+          type: "Disjunction",
+          loc: { begin: 1, end: 9 },
+          value: [
+            {
+              type: "Alternative",
+              loc: { begin: 1, end: 9 },
+              value: [
+                {
+                  type: "Group",
+                  loc: { begin: 1, end: 6 },
+                  capturing: false,
+                  value: {
+                    type: "Disjunction",
+                    loc: { begin: 4, end: 5 },
+                    value: [
+                      {
+                        type: "Alternative",
+                        loc: { begin: 4, end: 5 },
+                        value: [
+                          {
+                            type: "Character",
+                            loc: {
+                              begin: 4,
+                              end: 5
+                            },
+                            value: 97
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  type: "Group",
+                  loc: { begin: 6, end: 9 },
+                  capturing: true,
+                  value: {
+                    type: "Disjunction",
+                    loc: { begin: 7, end: 8 },
+                    value: [
+                      {
+                        type: "Alternative",
+                        loc: { begin: 7, end: 8 },
+                        value: [
+                          {
+                            type: "Character",
+                            loc: {
+                              begin: 7,
+                              end: 8
+                            },
+                            value: 98
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  idx: 1
+                }
+              ]
+            }
+          ]
+        })
+      })
+    })
+  })
+
+  context("Error Handling", () => {
+    it("unexpected end of input", () => {
+      const parse = () => parser.pattern("/a")
+      expect(parse).to.throw("Unexpected end of input")
+    })
+
+    it("unexpected character", () => {
+      const parse = () => parser.pattern("a")
+      expect(parse).to.throw("Expected: '/' but found: 'a' at offset: 0")
+    })
+  })
+})

--- a/packages/regexp-to-ast/test/visitor.spec.js
+++ b/packages/regexp-to-ast/test/visitor.spec.js
@@ -1,0 +1,256 @@
+const { RegExpParser, BaseRegExpVisitor } = require("../src/regexp-to-ast")
+const { expect } = require("chai")
+
+describe("The regexp AST visitor", () => {
+  let parser
+
+  before(() => {
+    parser = new RegExpParser()
+  })
+
+  it("Can visit pattern", () => {
+    const ast = parser.pattern("/a|b/")
+    class PatternVisitor extends BaseRegExpVisitor {
+      visitPattern(node) {
+        super.visitPattern(node)
+        expect(node.value.value).to.have.lengthOf(2)
+      }
+    }
+
+    new PatternVisitor().visit(ast)
+  })
+
+  it("Can visit Disjunction", () => {
+    const ast = parser.pattern("/a|b|c/")
+    class DisjunctionVisitor extends BaseRegExpVisitor {
+      visitDisjunction(node) {
+        super.visitDisjunction(node)
+        expect(node.value).to.have.lengthOf(3)
+      }
+    }
+
+    new DisjunctionVisitor().visit(ast)
+  })
+
+  it("Can visit Alternative", () => {
+    const ast = parser.pattern("/a|b|c|d/")
+    let times = 0
+    class AlternativeVisitor extends BaseRegExpVisitor {
+      visitAlternative(node) {
+        super.visitAlternative(node)
+        times++
+      }
+    }
+
+    new AlternativeVisitor().visit(ast)
+    expect(times).to.equal(4)
+  })
+
+  it("Can visit StartAnchor", () => {
+    const ast = parser.pattern("/^^abc/")
+    let times = 0
+    class StartAnchorVisitor extends BaseRegExpVisitor {
+      visitStartAnchor(node) {
+        super.visitStartAnchor(node)
+        times++
+      }
+    }
+
+    new StartAnchorVisitor().visit(ast)
+    expect(times).to.equal(2)
+  })
+
+  it("Can visit EndAnchor", () => {
+    const ast = parser.pattern("/abc$$$/")
+    let times = 0
+    class EndAnchorVisitor extends BaseRegExpVisitor {
+      visitEndAnchor(node) {
+        super.visitEndAnchor(node)
+        times++
+      }
+    }
+
+    new EndAnchorVisitor().visit(ast)
+    expect(times).to.equal(3)
+  })
+
+  it("Can visit WordBoundary", () => {
+    const ast = parser.pattern("/abc\\b\\b\\b\\b/")
+    let times = 0
+    class WordBoundaryVisitor extends BaseRegExpVisitor {
+      visitWordBoundary(node) {
+        super.visitWordBoundary(node)
+        times++
+      }
+    }
+
+    new WordBoundaryVisitor().visit(ast)
+    expect(times).to.equal(4)
+  })
+
+  it("Can visit NonWordBoundary", () => {
+    const ast = parser.pattern("/abc\\B\\B\\B/")
+    let times = 0
+    class NonWordBoundaryVisitor extends BaseRegExpVisitor {
+      visitNonWordBoundary(node) {
+        super.visitNonWordBoundary(node)
+        times++
+      }
+    }
+
+    new NonWordBoundaryVisitor().visit(ast)
+    expect(times).to.equal(3)
+  })
+
+  it("Can visit Lookahead", () => {
+    const ast = parser.pattern("/a(?=a|b)/")
+    class LookaheadVisitor extends BaseRegExpVisitor {
+      visitLookahead(node) {
+        super.visitLookahead(node)
+        expect(node.value.value).to.have.lengthOf(2)
+      }
+    }
+
+    new LookaheadVisitor().visit(ast)
+  })
+
+  it("Can visit NegativeLookahead", () => {
+    const ast = parser.pattern("/a(?!a|b|c)/")
+    class NegativeLookaheadVisitor extends BaseRegExpVisitor {
+      visitNegativeLookahead(node) {
+        super.visitNegativeLookahead(node)
+        expect(node.value.value).to.have.lengthOf(3)
+      }
+    }
+
+    new NegativeLookaheadVisitor().visit(ast)
+  })
+
+  it("Can visit Character", () => {
+    const ast = parser.pattern("/a/")
+    class CharacterVisitor extends BaseRegExpVisitor {
+      visitCharacter(node) {
+        super.visitCharacter(node)
+        expect(node.value).to.equal(97)
+      }
+    }
+
+    new CharacterVisitor().visit(ast)
+  })
+
+  it("Can visit Character with quantifier", () => {
+    const ast = parser.pattern("/a*/")
+    class CharacterVisitor extends BaseRegExpVisitor {
+      visitCharacter(node) {
+        super.visitCharacter(node)
+        expect(node.value).to.equal(97)
+        expect(node.quantifier.atLeast).to.equal(0)
+        expect(node.quantifier.atMost).to.equal(Infinity)
+      }
+    }
+
+    new CharacterVisitor().visit(ast)
+  })
+
+  it("Can visit Set", () => {
+    const ast = parser.pattern("/[abc]/")
+    class SetVisitor extends BaseRegExpVisitor {
+      visitSet(node) {
+        super.visitSet(node)
+        expect(node.value).to.deep.equal([97, 98, 99])
+      }
+    }
+
+    new SetVisitor().visit(ast)
+  })
+
+  it("Can visit Set with range", () => {
+    const ast = parser.pattern("/[a-z]/")
+    class SetVisitor extends BaseRegExpVisitor {
+      visitSet(node) {
+        super.visitSet(node)
+        expect(node.value).to.deep.equal([{ from: 97, to: 122 }])
+      }
+    }
+
+    new SetVisitor().visit(ast)
+  })
+
+  it("Can visit Set with quantifier", () => {
+    const ast = parser.pattern("/[abc]{1,4}/")
+    class SetVisitor extends BaseRegExpVisitor {
+      visitSet(node) {
+        super.visitSet(node)
+        expect(node.value).to.deep.equal([97, 98, 99])
+        expect(node.quantifier.atLeast).to.equal(1)
+        expect(node.quantifier.atMost).to.equal(4)
+      }
+    }
+
+    new SetVisitor().visit(ast)
+  })
+
+  it("Can visit Group", () => {
+    const ast = parser.pattern("/(a|b|c)/")
+    class GroupVisitor extends BaseRegExpVisitor {
+      visitGroup(node) {
+        super.visitGroup(node)
+        expect(node.value.value).to.have.lengthOf(3)
+      }
+    }
+
+    new GroupVisitor().visit(ast)
+  })
+
+  it("Can visit Group with quantifier", () => {
+    const ast = parser.pattern("/(a|b|c)?/")
+    class GroupVisitor extends BaseRegExpVisitor {
+      visitGroup(node) {
+        super.visitGroup(node)
+        expect(node.value.value).to.have.lengthOf(3)
+        expect(node.quantifier.atLeast).to.equal(0)
+        expect(node.quantifier.atMost).to.equal(1)
+      }
+    }
+
+    new GroupVisitor().visit(ast)
+  })
+
+  it("Can visit Group back reference", () => {
+    const ast = parser.pattern("/(ab)\\1/")
+    class GroupBackReferenceVisitor extends BaseRegExpVisitor {
+      visitGroupBackReference(node) {
+        super.visitGroupBackReference(node)
+        expect(node.value).to.equal(1)
+      }
+    }
+
+    new GroupBackReferenceVisitor().visit(ast)
+  })
+
+  it("Can visit Group back reference with quantifier", () => {
+    const ast = parser.pattern("/(ab)\\1{666}/")
+    class GroupBackReferenceVisitor extends BaseRegExpVisitor {
+      visitGroupBackReference(node) {
+        super.visitGroupBackReference(node)
+        expect(node.value).to.equal(1)
+        expect(node.quantifier.atLeast).to.equal(666)
+        expect(node.quantifier.atMost).to.equal(666)
+      }
+    }
+
+    new GroupBackReferenceVisitor().visit(ast)
+  })
+
+  it("Can visit Quantifier", () => {
+    const ast = parser.pattern("/a{1,3}/")
+    class QuantifierVisitor extends BaseRegExpVisitor {
+      visitQuantifier(node) {
+        super.visitQuantifier(node)
+        expect(node.atMost).to.equal(3)
+      }
+    }
+
+    new QuantifierVisitor().visit(ast)
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,6 +197,22 @@ importers:
     devDependencies:
       '@types/lodash': 4.14.191
 
+  packages/regexp-to-ast:
+    specifiers:
+      chai: 4.3.7
+      eslint: 8.30.0
+      eslint-config-prettier: 8.5.0
+      eslint-plugin-es5: ^1.4.1
+      gitty: ^3.7.0
+      mocha: 10.2.0
+    devDependencies:
+      chai: 4.3.7
+      eslint: 8.30.0
+      eslint-config-prettier: 8.5.0_eslint@8.30.0
+      eslint-plugin-es5: 1.5.0_eslint@8.30.0
+      gitty: 3.7.2
+      mocha: 10.2.0
+
   packages/types:
     specifiers:
       typedoc: 0.23.23
@@ -573,15 +589,6 @@ packages:
       conventional-changelog-conventionalcommits: 5.0.0
     dev: true
 
-  /@commitlint/config-validator/17.0.3:
-    resolution: {integrity: sha512-3tLRPQJKapksGE7Kee9axv+9z5I2GDHitDH4q63q7NmNA0wkB+DAorJ0RHz2/K00Zb1/MVdHzhCga34FJvDihQ==}
-    engines: {node: '>=v14'}
-    dependencies:
-      '@commitlint/types': 17.0.0
-      ajv: 8.11.0
-    dev: true
-    optional: true
-
   /@commitlint/config-validator/17.1.0:
     resolution: {integrity: sha512-Q1rRRSU09ngrTgeTXHq6ePJs2KrI+axPTgkNYDWSJIuS1Op4w3J30vUfSXjwn5YEJHklK3fSqWNHmBhmTR7Vdg==}
     engines: {node: '>=v14'}
@@ -633,31 +640,10 @@ packages:
       '@commitlint/types': 17.0.0
     dev: true
 
-  /@commitlint/load/17.0.3:
-    resolution: {integrity: sha512-3Dhvr7GcKbKa/ey4QJ5MZH3+J7QFlARohUow6hftQyNjzoXXROm+RwpBes4dDFrXG1xDw9QPXA7uzrOShCd4bw==}
-    engines: {node: '>=v14'}
-    requiresBuild: true
-    dependencies:
-      '@commitlint/config-validator': 17.0.3
-      '@commitlint/execute-rule': 17.0.0
-      '@commitlint/resolve-extends': 17.0.3
-      '@commitlint/types': 17.0.0
-      '@types/node': 18.7.8
-      chalk: 4.1.2
-      cosmiconfig: 7.0.1
-      cosmiconfig-typescript-loader: 2.0.2_ic4ooz6cngxpec6gkztqpemn34
-      lodash: 4.17.21
-      resolve-from: 5.0.0
-      typescript: 4.9.4
-    transitivePeerDependencies:
-      - '@swc/core'
-      - '@swc/wasm'
-    dev: true
-    optional: true
-
   /@commitlint/load/17.3.0:
     resolution: {integrity: sha512-u/pV6rCAJrCUN+HylBHLzZ4qj1Ew3+eN9GBPhNi9otGxtOfA8b+8nJSxaNbcC23Ins/kcpjGf9zPSVW7628Umw==}
     engines: {node: '>=v14'}
+    requiresBuild: true
     dependencies:
       '@commitlint/config-validator': 17.1.0
       '@commitlint/execute-rule': 17.0.0
@@ -702,19 +688,6 @@ packages:
       git-raw-commits: 2.0.11
       minimist: 1.2.6
     dev: true
-
-  /@commitlint/resolve-extends/17.0.3:
-    resolution: {integrity: sha512-H/RFMvrcBeJCMdnVC4i8I94108UDccIHrTke2tyQEg9nXQnR5/Hd6MhyNWkREvcrxh9Y+33JLb+PiPiaBxCtBA==}
-    engines: {node: '>=v14'}
-    dependencies:
-      '@commitlint/config-validator': 17.1.0
-      '@commitlint/types': 17.0.0
-      import-fresh: 3.3.0
-      lodash: 4.17.21
-      resolve-from: 5.0.0
-      resolve-global: 1.0.0
-    dev: true
-    optional: true
 
   /@commitlint/resolve-extends/17.3.0:
     resolution: {integrity: sha512-Lf3JufJlc5yVEtJWC8o4IAZaB8FQAUaVlhlAHRACd0TTFizV2Lk2VH70et23KgvbQNf7kQzHs/2B4QZalBv6Cg==}
@@ -3176,7 +3149,7 @@ packages:
   /acorn-globals/7.0.1:
     resolution: {integrity: sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==}
     dependencies:
-      acorn: 8.8.1
+      acorn: 8.8.0
       acorn-walk: 8.2.0
     dev: true
 
@@ -3188,12 +3161,12 @@ packages:
       acorn: 8.8.1
     dev: true
 
-  /acorn-jsx/5.3.2_acorn@8.8.1:
+  /acorn-jsx/5.3.2_acorn@8.8.0:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      acorn: 8.8.1
+      acorn: 8.8.0
     dev: true
 
   /acorn-walk/8.2.0:
@@ -3205,7 +3178,6 @@ packages:
     resolution: {integrity: sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==}
     engines: {node: '>=0.4.0'}
     hasBin: true
-    dev: false
 
   /acorn/8.8.1:
     resolution: {integrity: sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==}
@@ -4054,23 +4026,6 @@ packages:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
     dev: true
 
-  /cosmiconfig-typescript-loader/2.0.2_ic4ooz6cngxpec6gkztqpemn34:
-    resolution: {integrity: sha512-KmE+bMjWMXJbkWCeY4FJX/npHuZPNr9XF9q9CIQ/bpFwi1qHfCmSiKarrCcRa0LO4fWjk93pVoeRtJAkTGcYNw==}
-    engines: {node: '>=12', npm: '>=6'}
-    peerDependencies:
-      '@types/node': '*'
-      typescript: '>=3'
-    dependencies:
-      '@types/node': 18.7.8
-      cosmiconfig: 7.0.1
-      ts-node: 10.9.1_ic4ooz6cngxpec6gkztqpemn34
-      typescript: 4.9.4
-    transitivePeerDependencies:
-      - '@swc/core'
-      - '@swc/wasm'
-    dev: true
-    optional: true
-
   /cosmiconfig-typescript-loader/4.3.0_ddhj5mna3wq7ixd2imxtjvlllm:
     resolution: {integrity: sha512-NTxV1MFfZDLPiBMjxbHRwSh5LaLcPMwNdCutmnHJCKoVnlvldPWlllonKwrsRJ5pYZBIBGRWWU2tfvzxgeSW5Q==}
     engines: {node: '>=12', npm: '>=6'}
@@ -4151,7 +4106,7 @@ packages:
       longest: 2.0.1
       word-wrap: 1.2.3
     optionalDependencies:
-      '@commitlint/load': 17.0.3
+      '@commitlint/load': 17.3.0
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -4791,6 +4746,14 @@ packages:
       eslint: 8.30.0
     dev: true
 
+  /eslint-plugin-es5/1.5.0_eslint@8.30.0:
+    resolution: {integrity: sha512-Qxmfo7v2B7SGAEURJo0dpBweFf+JU15kSyALfiB2rXWcBuJ96r6X9kFHXFnhdopPHCaHjoQs1xQPUJVbGMb1AA==}
+    peerDependencies:
+      eslint: '>= 3.0.0'
+    dependencies:
+      eslint: 8.30.0
+    dev: true
+
   /eslint-plugin-eslint-comments/3.2.0_eslint@8.30.0:
     resolution: {integrity: sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ==}
     engines: {node: '>=6.5.0'}
@@ -4900,8 +4863,8 @@ packages:
     resolution: {integrity: sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      acorn: 8.8.1
-      acorn-jsx: 5.3.2_acorn@8.8.1
+      acorn: 8.8.0
+      acorn-jsx: 5.3.2_acorn@8.8.0
       eslint-visitor-keys: 3.3.0
     dev: true
 
@@ -8691,7 +8654,7 @@ packages:
     hasBin: true
     dependencies:
       '@jridgewell/source-map': 0.3.2
-      acorn: 8.8.1
+      acorn: 8.8.0
       commander: 2.20.3
       source-map-support: 0.5.21
     dev: true
@@ -8792,38 +8755,6 @@ packages:
     resolution: {integrity: sha512-+1iDGY6NmOGidq7i7xZGA4cm8DAa6fqdYcvO5Z6yBevH++Bdo9Qt/mN0TzHUgcCcKv1gmh9+W5dHqz8pMWbCbg==}
     dev: true
 
-  /ts-node/10.9.1_ic4ooz6cngxpec6gkztqpemn34:
-    resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
-    hasBin: true
-    peerDependencies:
-      '@swc/core': '>=1.2.50'
-      '@swc/wasm': '>=1.2.50'
-      '@types/node': '*'
-      typescript: '>=2.7'
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      '@swc/wasm':
-        optional: true
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.9
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.3
-      '@types/node': 18.7.8
-      acorn: 8.8.1
-      acorn-walk: 8.2.0
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 4.9.4
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    dev: true
-    optional: true
-
   /ts-node/10.9.1_xplfzyzpegygk3axf4z63vz544:
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
@@ -8844,7 +8775,7 @@ packages:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
       '@types/node': 14.18.35
-      acorn: 8.8.1
+      acorn: 8.8.0
       acorn-walk: 8.2.0
       arg: 4.1.3
       create-require: 1.1.1


### PR DESCRIPTION
As requested as part of this [PR](https://github.com/bd82/regexp-to-ast/pull/129), I started to work on bringing regexp-to-ast to inside of the chevrotain mono repo.

Test is passing, I still need to figure out how to release.