### PR TITLE
Updated #1871 to remove lodash

### DIFF
--- a/packages/chevrotain/package.json
+++ b/packages/chevrotain/package.json
@@ -76,12 +76,10 @@
     "@chevrotain/cst-dts-gen": "10.4.2",
     "@chevrotain/gast": "10.4.2",
     "@chevrotain/types": "10.4.2",
-    "@chevrotain/utils": "10.4.2",
     "lodash": "4.17.21",
     "regexp-to-ast": "0.5.0"
   },
   "devDependencies": {
-    "@types/lodash": "4.14.191",
     "error-stack-parser": "2.1.4",
     "esbuild": "0.16.10",
     "gen-esm-wrapper": "1.1.3",

--- a/packages/chevrotain/package.json
+++ b/packages/chevrotain/package.json
@@ -32,7 +32,7 @@
     "lib/chevrotain.min.js",
     "lib/chevrotain.js",
     "src/**/*.ts",
-    "READNE.md",
+    "README.md",
     "LICENSE.TXT",
     "diagrams/**/*.*",
     "CHANGELOG.md"
@@ -76,7 +76,6 @@
     "@chevrotain/cst-dts-gen": "10.5.0",
     "@chevrotain/gast": "10.5.0",
     "@chevrotain/types": "10.5.0",
-    "lodash": "4.17.21",
     "regexp-to-ast": "0.5.0"
   },
   "devDependencies": {

--- a/packages/chevrotain/package.json
+++ b/packages/chevrotain/package.json
@@ -76,6 +76,7 @@
     "@chevrotain/cst-dts-gen": "10.5.0",
     "@chevrotain/gast": "10.5.0",
     "@chevrotain/types": "10.5.0",
+    "@chevrotain/utils": "10.5.0",
     "regexp-to-ast": "0.5.0"
   },
   "devDependencies": {

--- a/packages/chevrotain/src/parse/cst/cst_visitor.ts
+++ b/packages/chevrotain/src/parse/cst/cst_visitor.ts
@@ -1,17 +1,8 @@
-import isEmpty from "lodash/isEmpty"
-import compact from "lodash/compact"
-import isArray from "lodash/isArray"
-import map from "lodash/map"
-import forEach from "lodash/forEach"
-import filter from "lodash/filter"
-import keys from "lodash/keys"
-import isFunction from "lodash/isFunction"
-import isUndefined from "lodash/isUndefined"
 import { defineNameProp } from "../../lang/lang_extensions"
 import { CstNode, ICstVisitor } from "@chevrotain/types"
 
 export function defaultVisit<IN>(ctx: any, param: IN): void {
-  const childrenNames = keys(ctx)
+  const childrenNames = Object.keys(ctx)
   const childrenNamesLength = childrenNames.length
   for (let i = 0; i < childrenNamesLength; i++) {
     const currChildName = childrenNames[i]
@@ -44,14 +35,14 @@ export function createBaseSemanticVisitorConstructor(
   const semanticProto = {
     visit: function (cstNode: CstNode | CstNode[], param: any) {
       // enables writing more concise visitor methods when CstNode has only a single child
-      if (isArray(cstNode)) {
+      if (Array.isArray(cstNode)) {
         // A CST Node's children dictionary can never have empty arrays as values
         // If a key is defined there will be at least one element in the corresponding value array.
         cstNode = cstNode[0]
       }
 
       // enables passing optional CstNodes concisely.
-      if (isUndefined(cstNode)) {
+      if (cstNode === undefined) {
         return undefined
       }
 
@@ -60,9 +51,8 @@ export function createBaseSemanticVisitorConstructor(
 
     validateVisitor: function () {
       const semanticDefinitionErrors = validateVisitor(this, ruleNames)
-      if (!isEmpty(semanticDefinitionErrors)) {
-        const errorMessages = map(
-          semanticDefinitionErrors,
+      if (semanticDefinitionErrors.length > 0) {
+        const errorMessages = semanticDefinitionErrors.map(
           (currDefError) => currDefError.msg
         )
         throw Error(
@@ -96,7 +86,7 @@ export function createBaseVisitorConstructorWithDefaults(
   defineNameProp(derivedConstructor, grammarName + "BaseSemanticsWithDefaults")
 
   const withDefaultsProto = Object.create(baseConstructor.prototype)
-  forEach(ruleNames, (ruleName) => {
+  ruleNames.forEach((ruleName) => {
     withDefaultsProto[ruleName] = defaultVisit
   })
 
@@ -130,12 +120,11 @@ export function validateMissingCstMethods(
   visitorInstance: ICstVisitor<unknown, unknown>,
   ruleNames: string[]
 ): IVisitorDefinitionError[] {
-  const missingRuleNames = filter(ruleNames, (currRuleName) => {
-    return isFunction((visitorInstance as any)[currRuleName]) === false
+  const missingRuleNames = ruleNames.filter((currRuleName) => {
+    return typeof (visitorInstance as any)[currRuleName] !== "function"
   })
 
-  const errors: IVisitorDefinitionError[] = map(
-    missingRuleNames,
+  const errors: IVisitorDefinitionError[] = missingRuleNames.map(
     (currRuleName) => {
       return {
         msg: `Missing visitor method: <${currRuleName}> on ${<any>(
@@ -147,5 +136,5 @@ export function validateMissingCstMethods(
     }
   )
 
-  return compact<IVisitorDefinitionError>(errors)
+  return errors.filter((err) => !!err)
 }

--- a/packages/chevrotain/src/parse/errors_public.ts
+++ b/packages/chevrotain/src/parse/errors_public.ts
@@ -1,7 +1,4 @@
 import { hasTokenLabel, tokenLabel } from "../scan/tokens_public"
-import first from "lodash/first"
-import map from "lodash/map"
-import reduce from "lodash/reduce"
 import { Alternation, NonTerminal, Rule, Terminal } from "@chevrotain/gast"
 import { getProductionDslName } from "@chevrotain/gast"
 import {
@@ -39,26 +36,23 @@ export const defaultParserErrorProvider: IParserErrorMessageProvider = {
   }): string {
     const errPrefix = "Expecting: "
     // TODO: issue: No Viable Alternative Error may have incomplete details. #502
-    const actualText = first(actual)!.image
+    const actualText = actual[0]!.image
     const errSuffix = "\nbut found: '" + actualText + "'"
 
     if (customUserDescription) {
       return errPrefix + customUserDescription + errSuffix
     } else {
-      const allLookAheadPaths = reduce(
-        expectedPathsPerAlt,
+      const allLookAheadPaths = expectedPathsPerAlt.reduce(
         (result, currAltPaths) => result.concat(currAltPaths),
         [] as TokenType[][]
       )
-      const nextValidTokenSequences = map(
-        allLookAheadPaths,
+      const nextValidTokenSequences = allLookAheadPaths.map(
         (currPath) =>
-          `[${map(currPath, (currTokenType) => tokenLabel(currTokenType)).join(
-            ", "
-          )}]`
+          `[${currPath
+            .map((currTokenType) => tokenLabel(currTokenType))
+            .join(", ")}]`
       )
-      const nextValidSequenceItems = map(
-        nextValidTokenSequences,
+      const nextValidSequenceItems = nextValidTokenSequences.map(
         (itemMsg, idx) => `  ${idx + 1}. ${itemMsg}`
       )
       const calculatedDescription = `one of these possible Token sequences:\n${nextValidSequenceItems.join(
@@ -77,18 +71,17 @@ export const defaultParserErrorProvider: IParserErrorMessageProvider = {
   }): string {
     const errPrefix = "Expecting: "
     // TODO: issue: No Viable Alternative Error may have incomplete details. #502
-    const actualText = first(actual)!.image
+    const actualText = actual[0]!.image
     const errSuffix = "\nbut found: '" + actualText + "'"
 
     if (customUserDescription) {
       return errPrefix + customUserDescription + errSuffix
     } else {
-      const nextValidTokenSequences = map(
-        expectedIterationPaths,
+      const nextValidTokenSequences = expectedIterationPaths.map(
         (currPath) =>
-          `[${map(currPath, (currTokenType) => tokenLabel(currTokenType)).join(
-            ","
-          )}]`
+          `[${currPath
+            .map((currTokenType) => tokenLabel(currTokenType))
+            .join(",")}]`
       )
       const calculatedDescription =
         `expecting at least one iteration which starts with one of these possible Token sequences::\n  ` +
@@ -137,7 +130,7 @@ export const defaultGrammarValidatorErrorProvider: IGrammarValidatorErrorMessage
       }
 
       const topLevelName = topLevelRule.name
-      const duplicateProd = first(duplicateProds)!
+      const duplicateProd = duplicateProds[0]!
       const index = duplicateProd.idx
       const dslName = getProductionDslName(duplicateProd)
       const extraArgument = getExtraProductionArgument(duplicateProd)
@@ -176,9 +169,9 @@ export const defaultGrammarValidatorErrorProvider: IGrammarValidatorErrorMessage
       ambiguityIndices: number[]
       alternation: Alternation
     }): string {
-      const pathMsg = map(options.prefixPath, (currTok) =>
-        tokenLabel(currTok)
-      ).join(", ")
+      const pathMsg = options.prefixPath
+        .map((currTok) => tokenLabel(currTok))
+        .join(", ")
       const occurrence =
         options.alternation.idx === 0 ? "" : options.alternation.idx
       const errMsg =
@@ -199,9 +192,9 @@ export const defaultGrammarValidatorErrorProvider: IGrammarValidatorErrorMessage
       ambiguityIndices: number[]
       alternation: Alternation
     }): string {
-      const pathMsg = map(options.prefixPath, (currtok) =>
-        tokenLabel(currtok)
-      ).join(", ")
+      const pathMsg = options.prefixPath
+        .map((currtok) => tokenLabel(currtok))
+        .join(", ")
       const occurrence =
         options.alternation.idx === 0 ? "" : options.alternation.idx
       let currMessage =
@@ -277,8 +270,7 @@ export const defaultGrammarValidatorErrorProvider: IGrammarValidatorErrorMessage
       leftRecursionPath: Rule[]
     }): string {
       const ruleName = options.topLevelRule.name
-      const pathNames = map(
-        options.leftRecursionPath,
+      const pathNames = options.leftRecursionPath.map(
         (currRule) => currRule.name
       )
       const leftRecursivePath = `${ruleName} --> ${pathNames

--- a/packages/chevrotain/src/parse/exceptions_public.ts
+++ b/packages/chevrotain/src/parse/exceptions_public.ts
@@ -1,4 +1,3 @@
-import includes from "lodash/includes"
 import {
   IToken,
   IRecognitionException,
@@ -22,7 +21,7 @@ Object.freeze(RECOGNITION_EXCEPTION_NAMES)
 // hacks to bypass no support for custom Errors in javascript/typescript
 export function isRecognitionException(error: Error) {
   // can't do instanceof on hacked custom js exceptions
-  return includes(RECOGNITION_EXCEPTION_NAMES, error.name)
+  return RECOGNITION_EXCEPTION_NAMES.indexOf(error.name) !== -1
 }
 
 abstract class RecognitionException

--- a/packages/chevrotain/src/parse/grammar/follow.ts
+++ b/packages/chevrotain/src/parse/grammar/follow.ts
@@ -1,7 +1,5 @@
 import { RestWalker } from "./rest"
 import { first } from "./first"
-import forEach from "lodash/forEach"
-import assign from "lodash/assign"
 import { IN } from "../constants"
 import { Alternative, NonTerminal, Rule, Terminal } from "@chevrotain/gast"
 import { IProduction, TokenType } from "@chevrotain/types"
@@ -48,9 +46,9 @@ export function computeAllProdsFollows(
 ): Record<string, TokenType[]> {
   const reSyncFollows = {}
 
-  forEach(topProductions, (topProd) => {
+  topProductions.forEach((topProd) => {
     const currRefsFollow = new ResyncFollowsWalker(topProd).startWalking()
-    assign(reSyncFollows, currRefsFollow)
+    Object.assign(reSyncFollows, currRefsFollow)
   })
   return reSyncFollows
 }

--- a/packages/chevrotain/src/parse/grammar/gast/gast_resolver_public.ts
+++ b/packages/chevrotain/src/parse/grammar/gast/gast_resolver_public.ts
@@ -1,6 +1,4 @@
 import { Rule } from "@chevrotain/gast"
-import forEach from "lodash/forEach"
-import defaults from "lodash/defaults"
 import { resolveGrammar as orgResolveGrammar } from "../resolver"
 import { validateGrammar as orgValidateGrammar } from "../checks"
 import {
@@ -21,12 +19,13 @@ type ResolveGrammarOpts = {
 export function resolveGrammar(
   options: ResolveGrammarOpts
 ): IParserDefinitionError[] {
-  const actualOptions: Required<ResolveGrammarOpts> = defaults(options, {
-    errMsgProvider: defaultGrammarResolverErrorProvider
-  })
+  const actualOptions: Required<ResolveGrammarOpts> = {
+    errMsgProvider: defaultGrammarResolverErrorProvider,
+    ...options
+  }
 
   const topRulesTable: { [ruleName: string]: Rule } = {}
-  forEach(options.rules, (rule) => {
+  options.rules.forEach((rule) => {
     topRulesTable[rule.name] = rule
   })
   return orgResolveGrammar(topRulesTable, actualOptions.errMsgProvider)
@@ -36,16 +35,12 @@ export function validateGrammar(options: {
   rules: Rule[]
   tokenTypes: TokenType[]
   grammarName: string
-  errMsgProvider: IGrammarValidatorErrorMessageProvider
+  errMsgProvider?: IGrammarValidatorErrorMessageProvider
 }): IParserDefinitionError[] {
-  options = defaults(options, {
-    errMsgProvider: defaultGrammarValidatorErrorProvider
-  })
-
   return orgValidateGrammar(
     options.rules,
     options.tokenTypes,
-    options.errMsgProvider,
+    options.errMsgProvider ?? defaultGrammarValidatorErrorProvider,
     options.grammarName
   )
 }

--- a/packages/chevrotain/src/parse/grammar/llk_lookahead.ts
+++ b/packages/chevrotain/src/parse/grammar/llk_lookahead.ts
@@ -6,8 +6,6 @@ import {
   TokenType,
   OptionalProductionType
 } from "@chevrotain/types"
-import flatMap from "lodash/flatMap"
-import isEmpty from "lodash/isEmpty"
 import { defaultGrammarValidatorErrorProvider } from "../errors_public"
 import { DEFAULT_PARSER_CONFIG } from "../parser/parser"
 import {
@@ -25,6 +23,11 @@ import {
 } from "./lookahead"
 import { IParserDefinitionError } from "./types"
 
+// ES2019 Array.prototype.flatMap
+function flatMap<U, R>(arr: U[], callback: (x: U, idx: number) => R[]): R[] {
+  return Array.prototype.concat.apply([], arr.map(callback))
+}
+
 export class LLkLookaheadStrategy implements ILookaheadStrategy {
   readonly maxLookahead: number
 
@@ -40,7 +43,7 @@ export class LLkLookaheadStrategy implements ILookaheadStrategy {
   }): ILookaheadValidationError[] {
     const leftRecursionErrors = this.validateNoLeftRecursion(options.rules)
 
-    if (isEmpty(leftRecursionErrors)) {
+    if (leftRecursionErrors.length === 0) {
       const emptyAltErrors = this.validateEmptyOrAlternatives(options.rules)
       const ambiguousAltsErrors = this.validateAmbiguousAlternationAlternatives(
         options.rules,

--- a/packages/chevrotain/src/parse/grammar/resolver.ts
+++ b/packages/chevrotain/src/parse/grammar/resolver.ts
@@ -2,8 +2,6 @@ import {
   IParserUnresolvedRefDefinitionError,
   ParserDefinitionErrorType
 } from "../parser/parser"
-import forEach from "lodash/forEach"
-import values from "lodash/values"
 import { NonTerminal, Rule } from "@chevrotain/gast"
 import { GAstVisitor } from "@chevrotain/gast"
 import {
@@ -32,7 +30,7 @@ export class GastRefResolverVisitor extends GAstVisitor {
   }
 
   public resolveRefs(): void {
-    forEach(values(this.nameToTopRule), (prod) => {
+    Object.values(this.nameToTopRule).forEach((prod) => {
       this.currTopLevel = prod
       prod.accept(this)
     })

--- a/packages/chevrotain/src/parse/grammar/rest.ts
+++ b/packages/chevrotain/src/parse/grammar/rest.ts
@@ -1,5 +1,3 @@
-import drop from "lodash/drop"
-import forEach from "lodash/forEach"
 import {
   Alternation,
   Alternative,
@@ -18,8 +16,8 @@ import { IProduction } from "@chevrotain/types"
  */
 export abstract class RestWalker {
   walk(prod: { definition: IProduction[] }, prevRest: any[] = []): void {
-    forEach(prod.definition, (subProd: IProduction, index) => {
-      const currRest = drop(prod.definition, index + 1)
+    prod.definition.forEach((subProd: IProduction, index) => {
+      const currRest = prod.definition.slice(index + 1)
       /* istanbul ignore else */
       if (subProd instanceof NonTerminal) {
         this.walkProdRef(subProd, currRest, prevRest)
@@ -137,7 +135,7 @@ export abstract class RestWalker {
     // ABC(D|E|F)G => when finding the (D|E|F) the rest is G
     const fullOrRest = currRest.concat(prevRest)
     // walk all different alternatives
-    forEach(orProd.definition, (alt) => {
+    orProd.definition.forEach((alt) => {
       // wrapping each alternative in a single definition wrapper
       // to avoid errors in computing the rest of that alternative in the invocation to computeInProdFollows
       // (otherwise for OR([alt1,alt2]) alt2 will be considered in 'rest' of alt1

--- a/packages/chevrotain/src/parse/parser/parser.ts
+++ b/packages/chevrotain/src/parse/parser/parser.ts
@@ -1,9 +1,3 @@
-import isEmpty from "lodash/isEmpty"
-import map from "lodash/map"
-import forEach from "lodash/forEach"
-import values from "lodash/values"
-import has from "lodash/has"
-import clone from "lodash/clone"
 import { toFastProperties } from "@chevrotain/utils"
 import { computeAllProdsFollows } from "../grammar/follow"
 import { createTokenInstance, EOF } from "../../scan/tokens_public"
@@ -169,7 +163,7 @@ export class Parser {
         try {
           this.enableRecording()
           // Building the GAST
-          forEach(this.definedRulesNames, (currRuleName) => {
+          this.definedRulesNames.forEach((currRuleName) => {
             const wrappedRule = (this as any)[
               currRuleName
             ] as ParserMethodInternal<unknown[], unknown>
@@ -191,7 +185,7 @@ export class Parser {
       let resolverErrors: IParserDefinitionError[] = []
       this.TRACE_INIT("Grammar Resolving", () => {
         resolverErrors = resolveGrammar({
-          rules: values(this.gastProductionsCache)
+          rules: Object.values(this.gastProductionsCache)
         })
         this.definitionErrors = this.definitionErrors.concat(resolverErrors)
       })
@@ -199,17 +193,17 @@ export class Parser {
       this.TRACE_INIT("Grammar Validations", () => {
         // only perform additional grammar validations IFF no resolving errors have occurred.
         // as unresolved grammar may lead to unhandled runtime exceptions in the follow up validations.
-        if (isEmpty(resolverErrors) && this.skipValidations === false) {
+        if (resolverErrors.length === 0 && this.skipValidations === false) {
           const validationErrors = validateGrammar({
-            rules: values(this.gastProductionsCache),
-            tokenTypes: values(this.tokensMap),
+            rules: Object.values(this.gastProductionsCache),
+            tokenTypes: Object.values(this.tokensMap),
             errMsgProvider: defaultGrammarValidatorErrorProvider,
             grammarName: className
           })
           const lookaheadValidationErrors = validateLookahead({
             lookaheadStrategy: this.lookaheadStrategy,
-            rules: values(this.gastProductionsCache),
-            tokenTypes: values(this.tokensMap),
+            rules: Object.values(this.gastProductionsCache),
+            tokenTypes: Object.values(this.tokensMap),
             grammarName: className
           })
           this.definitionErrors = this.definitionErrors.concat(
@@ -220,12 +214,12 @@ export class Parser {
       })
 
       // this analysis may fail if the grammar is not perfectly valid
-      if (isEmpty(this.definitionErrors)) {
+      if (this.definitionErrors.length === 0) {
         // The results of these computations are not needed unless error recovery is enabled.
         if (this.recoveryEnabled) {
           this.TRACE_INIT("computeAllProdsFollows", () => {
             const allFollows = computeAllProdsFollows(
-              values(this.gastProductionsCache)
+              Object.values(this.gastProductionsCache)
             )
             this.resyncFollows = allFollows
           })
@@ -233,18 +227,17 @@ export class Parser {
 
         this.TRACE_INIT("ComputeLookaheadFunctions", () => {
           this.lookaheadStrategy.initialize?.({
-            rules: values(this.gastProductionsCache)
+            rules: Object.values(this.gastProductionsCache)
           })
-          this.preComputeLookaheadFunctions(values(this.gastProductionsCache))
+          this.preComputeLookaheadFunctions(Object.values(this.gastProductionsCache))
         })
       }
 
       if (
         !Parser.DEFER_DEFINITION_ERRORS_HANDLING &&
-        !isEmpty(this.definitionErrors)
+        this.definitionErrors.length > 0
       ) {
-        defErrorsMsgs = map(
-          this.definitionErrors,
+        defErrorsMsgs = this.definitionErrors.map(
           (defError) => defError.message
         )
         throw new Error(
@@ -272,7 +265,7 @@ export class Parser {
     that.initGastRecorder(config)
     that.initPerformanceTracer(config)
 
-    if (has(config, "ignoredIssues")) {
+    if (config.hasOwnProperty("ignoredIssues")) {
       throw new Error(
         "The <ignoredIssues> IParserConfig property has been deprecated.\n\t" +
           "Please use the <IGNORE_AMBIGUITIES> flag on the relevant DSL method instead.\n\t" +
@@ -281,9 +274,8 @@ export class Parser {
       )
     }
 
-    this.skipValidations = has(config, "skipValidations")
-      ? (config.skipValidations as boolean) // casting assumes the end user passing the correct type
-      : DEFAULT_PARSER_CONFIG.skipValidations
+    this.skipValidations =
+      config.skipValidations ?? DEFAULT_PARSER_CONFIG.skipValidations
   }
 }
 
@@ -305,7 +297,7 @@ export class CstParser extends Parser {
     tokenVocabulary: TokenVocabulary,
     config: IParserConfigInternal = DEFAULT_PARSER_CONFIG
   ) {
-    const configClone = clone(config)
+    const configClone = Object.assign({}, config)
     configClone.outputCst = true
     super(tokenVocabulary, configClone)
   }
@@ -316,7 +308,7 @@ export class EmbeddedActionsParser extends Parser {
     tokenVocabulary: TokenVocabulary,
     config: IParserConfigInternal = DEFAULT_PARSER_CONFIG
   ) {
-    const configClone = clone(config)
+    const configClone = Object.assign({}, config)
     configClone.outputCst = false
     super(tokenVocabulary, configClone)
   }

--- a/packages/chevrotain/src/parse/parser/traits/context_assist.ts
+++ b/packages/chevrotain/src/parse/parser/traits/context_assist.ts
@@ -8,8 +8,6 @@ import {
   NextAfterTokenWalker,
   nextPossibleTokensAfter
 } from "../../grammar/interpreter"
-import first from "lodash/first"
-import isUndefined from "lodash/isUndefined"
 import { MixedInParser } from "./parser_traits"
 
 export class ContentAssist {
@@ -22,7 +20,7 @@ export class ContentAssist {
   ): ISyntacticContentAssistPath[] {
     const startRuleGast = this.gastProductionsCache[startRuleName]
 
-    if (isUndefined(startRuleGast)) {
+    if (startRuleGast === undefined) {
       throw Error(`Rule ->${startRuleName}<- does not exist in this grammar.`)
     }
 
@@ -40,7 +38,7 @@ export class ContentAssist {
     this: MixedInParser,
     grammarPath: ITokenGrammarPath
   ): TokenType[] {
-    const topRuleName = first(grammarPath.ruleStack)!
+    const topRuleName = grammarPath.ruleStack[0]
     const gastProductions = this.getGAstProductions()
     const topProduction = gastProductions[topRuleName]
     const nextPossibleTokenTypes = new NextAfterTokenWalker(

--- a/packages/chevrotain/src/parse/parser/traits/error_handler.ts
+++ b/packages/chevrotain/src/parse/parser/traits/error_handler.ts
@@ -8,8 +8,6 @@ import {
   isRecognitionException,
   NoViableAltException
 } from "../../exceptions_public"
-import has from "lodash/has"
-import clone from "lodash/clone"
 import {
   getLookaheadPathsForOptionalProd,
   getLookaheadPathsForOr,
@@ -27,9 +25,8 @@ export class ErrorHandler {
 
   initErrorHandler(config: IParserConfig) {
     this._errors = []
-    this.errorMessageProvider = has(config, "errorMessageProvider")
-      ? (config.errorMessageProvider as IParserErrorMessageProvider) // assumes end user provides the correct config value/type
-      : DEFAULT_PARSER_CONFIG.errorMessageProvider
+    this.errorMessageProvider =
+      config.errorMessageProvider ?? DEFAULT_PARSER_CONFIG.errorMessageProvider
   }
 
   SAVE_ERROR(
@@ -39,7 +36,7 @@ export class ErrorHandler {
     if (isRecognitionException(error)) {
       error.context = {
         ruleStack: this.getHumanReadableRuleStack(),
-        ruleOccurrenceStack: clone(this.RULE_OCCURRENCE_STACK)
+        ruleOccurrenceStack: this.RULE_OCCURRENCE_STACK.slice()
       }
       this._errors.push(error)
       return error
@@ -49,7 +46,7 @@ export class ErrorHandler {
   }
 
   get errors(): IRecognitionException[] {
-    return clone(this._errors)
+    return this._errors.slice()
   }
 
   set errors(newErrors: IRecognitionException[]) {

--- a/packages/chevrotain/src/parse/parser/traits/looksahead.ts
+++ b/packages/chevrotain/src/parse/parser/traits/looksahead.ts
@@ -1,5 +1,3 @@
-import forEach from "lodash/forEach"
-import has from "lodash/has"
 import { DEFAULT_PARSER_CONFIG } from "../parser"
 import {
   ILookaheadStrategy,
@@ -39,23 +37,19 @@ export class LooksAhead {
   lookaheadStrategy: ILookaheadStrategy
 
   initLooksAhead(config: IParserConfig) {
-    this.dynamicTokensEnabled = has(config, "dynamicTokensEnabled")
-      ? (config.dynamicTokensEnabled as boolean) // assumes end user provides the correct config value/type
-      : DEFAULT_PARSER_CONFIG.dynamicTokensEnabled
-
-    this.maxLookahead = has(config, "maxLookahead")
-      ? (config.maxLookahead as number) // assumes end user provides the correct config value/type
-      : DEFAULT_PARSER_CONFIG.maxLookahead
-
-    this.lookaheadStrategy = has(config, "lookaheadStrategy")
-      ? (config.lookaheadStrategy as ILookaheadStrategy) // assumes end user provides the correct config value/type
-      : new LLkLookaheadStrategy({ maxLookahead: this.maxLookahead })
+    this.dynamicTokensEnabled =
+      config.dynamicTokensEnabled ?? DEFAULT_PARSER_CONFIG.dynamicTokensEnabled
+    this.maxLookahead =
+      config.maxLookahead ?? DEFAULT_PARSER_CONFIG.maxLookahead
+    this.lookaheadStrategy =
+      config.lookaheadStrategy ??
+      new LLkLookaheadStrategy({ maxLookahead: this.maxLookahead })
 
     this.lookAheadFuncsCache = new Map()
   }
 
   preComputeLookaheadFunctions(this: MixedInParser, rules: Rule[]): void {
-    forEach(rules, (currRule) => {
+    rules.forEach((currRule) => {
       this.TRACE_INIT(`${currRule.name} Rule Lookahead`, () => {
         const {
           alternation,
@@ -66,7 +60,7 @@ export class LooksAhead {
           repetitionWithSeparator
         } = collectMethods(currRule)
 
-        forEach(alternation, (currProd) => {
+        alternation.forEach((currProd) => {
           const prodIdx = currProd.idx === 0 ? "" : currProd.idx
           this.TRACE_INIT(`${getProductionDslName(currProd)}${prodIdx}`, () => {
             const laFunc = this.lookaheadStrategy.buildLookaheadForAlternation({
@@ -86,7 +80,7 @@ export class LooksAhead {
           })
         })
 
-        forEach(repetition, (currProd) => {
+        repetition.forEach((currProd) => {
           this.computeLookaheadFunc(
             currRule,
             currProd.idx,
@@ -97,7 +91,7 @@ export class LooksAhead {
           )
         })
 
-        forEach(option, (currProd) => {
+        option.forEach((currProd) => {
           this.computeLookaheadFunc(
             currRule,
             currProd.idx,
@@ -108,7 +102,7 @@ export class LooksAhead {
           )
         })
 
-        forEach(repetitionMandatory, (currProd) => {
+        repetitionMandatory.forEach((currProd) => {
           this.computeLookaheadFunc(
             currRule,
             currProd.idx,
@@ -119,7 +113,7 @@ export class LooksAhead {
           )
         })
 
-        forEach(repetitionMandatoryWithSeparator, (currProd) => {
+        repetitionMandatoryWithSeparator.forEach((currProd) => {
           this.computeLookaheadFunc(
             currRule,
             currProd.idx,
@@ -130,7 +124,7 @@ export class LooksAhead {
           )
         })
 
-        forEach(repetitionWithSeparator, (currProd) => {
+        repetitionWithSeparator.forEach((currProd) => {
           this.computeLookaheadFunc(
             currRule,
             currProd.idx,

--- a/packages/chevrotain/src/parse/parser/traits/perf_tracer.ts
+++ b/packages/chevrotain/src/parse/parser/traits/perf_tracer.ts
@@ -1,5 +1,4 @@
 import { IParserConfig } from "@chevrotain/types"
-import has from "lodash/has"
 import { timer } from "@chevrotain/utils"
 import { MixedInParser } from "./parser_traits"
 import { DEFAULT_PARSER_CONFIG } from "../parser"
@@ -13,7 +12,7 @@ export class PerformanceTracer {
   traceInitIndent: number
 
   initPerformanceTracer(config: IParserConfig) {
-    if (has(config, "traceInitPerf")) {
+    if (config.traceInitPerf) {
       const userTraceInitPerf = config.traceInitPerf
       const traceIsNumber = typeof userTraceInitPerf === "number"
       this.traceInitMaxIdent = traceIsNumber

--- a/packages/chevrotain/src/parse/parser/traits/recognizer_api.ts
+++ b/packages/chevrotain/src/parse/parser/traits/recognizer_api.ts
@@ -13,8 +13,6 @@ import {
   SubruleMethodOpts,
   TokenType
 } from "@chevrotain/types"
-import values from "lodash/values"
-import includes from "lodash/includes"
 import { isRecognitionException } from "../../exceptions_public"
 import { DEFAULT_RULE_CONFIG, ParserDefinitionErrorType } from "../parser"
 import { defaultGrammarValidatorErrorProvider } from "../../errors_public"
@@ -643,7 +641,7 @@ export class RecognizerApi {
     implementation: (...implArgs: any[]) => T,
     config: IRuleConfig<T> = DEFAULT_RULE_CONFIG
   ): (idxInCallingRule?: number, ...args: any[]) => T | any {
-    if (includes(this.definedRulesNames, name)) {
+    if (this.definedRulesNames.indexOf(name) !== -1) {
       const errMsg =
         defaultGrammarValidatorErrorProvider.buildDuplicateRuleNameError({
           topLevelRule: name,
@@ -715,6 +713,6 @@ export class RecognizerApi {
   }
 
   public getSerializedGastProductions(this: MixedInParser): ISerializedGast[] {
-    return serializeGrammar(values(this.gastProductionsCache))
+    return serializeGrammar(Object.values(this.gastProductionsCache))
   }
 }

--- a/packages/chevrotain/src/parse/parser/traits/recoverable.ts
+++ b/packages/chevrotain/src/parse/parser/traits/recoverable.ts
@@ -7,14 +7,6 @@ import {
   AbstractNextTerminalAfterProductionWalker,
   IFirstAfterRepetition
 } from "../../grammar/interpreter"
-import isEmpty from "lodash/isEmpty"
-import dropRight from "lodash/dropRight"
-import flatten from "lodash/flatten"
-import map from "lodash/map"
-import find from "lodash/find"
-import has from "lodash/has"
-import includes from "lodash/includes"
-import clone from "lodash/clone"
 import {
   IParserConfig,
   IToken,
@@ -55,9 +47,8 @@ export class Recoverable {
     this.firstAfterRepMap = {}
     this.resyncFollows = {}
 
-    this.recoveryEnabled = has(config, "recoveryEnabled")
-      ? (config.recoveryEnabled as boolean) // assumes end user provides the correct config value/type
-      : DEFAULT_PARSER_CONFIG.recoveryEnabled
+    this.recoveryEnabled =
+      config.recoveryEnabled ?? DEFAULT_PARSER_CONFIG.recoveryEnabled
 
     // performance optimization, NOOP will be inlined which
     // effectively means that this optional feature does not exist
@@ -122,7 +113,7 @@ export class Recoverable {
         this.LA(0)
       )
       // the first token here will be the original cause of the error, this is not part of the resyncedTokens property.
-      error.resyncedTokens = dropRight(resyncedTokens)
+      error.resyncedTokens = resyncedTokens.slice(0, -1)
       this.SAVE_ERROR(error)
     }
 
@@ -240,13 +231,13 @@ export class Recoverable {
     }
 
     // must know the possible following tokens to perform single token insertion
-    if (isEmpty(follows)) {
+    if (follows.length === 0) {
       return false
     }
 
     const mismatchedTok = this.LA(1)
     const isMisMatchedTokInFollows =
-      find(follows, (possibleFollowsTokType: TokenType) => {
+      follows.find((possibleFollowsTokType: TokenType) => {
         return this.tokenMatcher(mismatchedTok, possibleFollowsTokType)
       }) !== undefined
 
@@ -274,7 +265,7 @@ export class Recoverable {
   ): boolean {
     const followKey = this.getCurrFollowKey()
     const currentRuleReSyncSet = this.getFollowSetFromFollowKey(followKey)
-    return includes(currentRuleReSyncSet, tokenTypeIdx)
+    return currentRuleReSyncSet.indexOf(tokenTypeIdx) !== -1
   }
 
   findReSyncTokenType(this: MixedInParser): TokenType {
@@ -283,7 +274,7 @@ export class Recoverable {
     let nextToken = this.LA(1)
     let k = 2
     while (true) {
-      const foundMatch = find(allPossibleReSyncTokTypes, (resyncTokType) => {
+      const foundMatch = allPossibleReSyncTokTypes.find((resyncTokType) => {
         const canMatch = tokenMatcher(nextToken, resyncTokType)
         return canMatch
       })
@@ -315,7 +306,7 @@ export class Recoverable {
     const explicitRuleStack = this.RULE_STACK
     const explicitOccurrenceStack = this.RULE_OCCURRENCE_STACK
 
-    return map(explicitRuleStack, (ruleName, idx) => {
+    return explicitRuleStack.map((ruleName, idx) => {
       if (idx === 0) {
         return EOF_FOLLOW_KEY
       }
@@ -328,10 +319,10 @@ export class Recoverable {
   }
 
   flattenFollowSet(this: MixedInParser): TokenType[] {
-    const followStack = map(this.buildFullFollowKeyStack(), (currKey) => {
+    const followStack = this.buildFullFollowKeyStack().map((currKey) => {
       return this.getFollowSetFromFollowKey(currKey)
     })
-    return <any>flatten(followStack)
+    return ([] as TokenType[]).concat(...followStack)
   }
 
   getFollowSetFromFollowKey(
@@ -369,7 +360,7 @@ export class Recoverable {
       this.addToResyncTokens(nextTok, resyncedTokens)
     }
     // the last token is not part of the error.
-    return dropRight(resyncedTokens)
+    return resyncedTokens.slice(0, -1)
   }
 
   attemptInRepetitionRecovery(
@@ -392,7 +383,7 @@ export class Recoverable {
     tokIdxInRule: number
   ): ITokenGrammarPath {
     const pathRuleStack: string[] = this.getHumanReadableRuleStack()
-    const pathOccurrenceStack: number[] = clone(this.RULE_OCCURRENCE_STACK)
+    const pathOccurrenceStack: number[] = this.RULE_OCCURRENCE_STACK.slice()
     const grammarPath: any = {
       ruleStack: pathRuleStack,
       occurrenceStack: pathOccurrenceStack,
@@ -403,7 +394,7 @@ export class Recoverable {
     return grammarPath
   }
   getHumanReadableRuleStack(this: MixedInParser): string[] {
-    return map(this.RULE_STACK, (currShortName) =>
+    return this.RULE_STACK.map((currShortName) =>
       this.shortRuleNameToFullName(currShortName)
     )
   }

--- a/packages/chevrotain/src/parse/parser/traits/tree_builder.ts
+++ b/packages/chevrotain/src/parse/parser/traits/tree_builder.ts
@@ -4,10 +4,6 @@ import {
   setNodeLocationFull,
   setNodeLocationOnlyOffset
 } from "../../cst/cst"
-import noop from "lodash/noop"
-import has from "lodash/has"
-import keys from "lodash/keys"
-import isUndefined from "lodash/isUndefined"
 import {
   createBaseSemanticVisitorConstructor,
   createBaseVisitorConstructorWithDefaults
@@ -52,26 +48,25 @@ export class TreeBuilder {
     // outputCst is no longer exposed/defined in the pubic API
     this.outputCst = (config as any).outputCst
 
-    this.nodeLocationTracking = has(config, "nodeLocationTracking")
-      ? (config.nodeLocationTracking as nodeLocationTrackingOptions) // assumes end user provides the correct config value/type
-      : DEFAULT_PARSER_CONFIG.nodeLocationTracking
+    this.nodeLocationTracking =
+      config.nodeLocationTracking ?? DEFAULT_PARSER_CONFIG.nodeLocationTracking
 
     if (!this.outputCst) {
-      this.cstInvocationStateUpdate = noop
-      this.cstFinallyStateUpdate = noop
-      this.cstPostTerminal = noop
-      this.cstPostNonTerminal = noop
-      this.cstPostRule = noop
+      this.cstInvocationStateUpdate = () => {}
+      this.cstFinallyStateUpdate = () => {}
+      this.cstPostTerminal = () => {}
+      this.cstPostNonTerminal = () => {}
+      this.cstPostRule = () => {}
     } else {
       if (/full/i.test(this.nodeLocationTracking)) {
         if (this.recoveryEnabled) {
           this.setNodeLocationFromToken = setNodeLocationFull
           this.setNodeLocationFromNode = setNodeLocationFull
-          this.cstPostRule = noop
+          this.cstPostRule = () => {}
           this.setInitialNodeLocation = this.setInitialNodeLocationFullRecovery
         } else {
-          this.setNodeLocationFromToken = noop
-          this.setNodeLocationFromNode = noop
+          this.setNodeLocationFromToken = () => {}
+          this.setNodeLocationFromNode = () => {}
           this.cstPostRule = this.cstPostRuleFull
           this.setInitialNodeLocation = this.setInitialNodeLocationFullRegular
         }
@@ -79,21 +74,21 @@ export class TreeBuilder {
         if (this.recoveryEnabled) {
           this.setNodeLocationFromToken = <any>setNodeLocationOnlyOffset
           this.setNodeLocationFromNode = <any>setNodeLocationOnlyOffset
-          this.cstPostRule = noop
+          this.cstPostRule = () => {}
           this.setInitialNodeLocation =
             this.setInitialNodeLocationOnlyOffsetRecovery
         } else {
-          this.setNodeLocationFromToken = noop
-          this.setNodeLocationFromNode = noop
+          this.setNodeLocationFromToken = () => {}
+          this.setNodeLocationFromNode = () => {}
           this.cstPostRule = this.cstPostRuleOnlyOffset
           this.setInitialNodeLocation =
             this.setInitialNodeLocationOnlyOffsetRegular
         }
       } else if (/none/i.test(this.nodeLocationTracking)) {
-        this.setNodeLocationFromToken = noop
-        this.setNodeLocationFromNode = noop
-        this.cstPostRule = noop
-        this.setInitialNodeLocation = noop
+        this.setNodeLocationFromToken = () => {}
+        this.setNodeLocationFromNode = () => {}
+        this.cstPostRule = () => {}
+        this.setInitialNodeLocation = () => {}
       } else {
         throw Error(
           `Invalid <nodeLocationTracking> config option: "${config.nodeLocationTracking}"`
@@ -231,10 +226,10 @@ export class TreeBuilder {
   ): {
     new (...args: any[]): ICstVisitor<IN, OUT>
   } {
-    if (isUndefined(this.baseCstVisitorConstructor)) {
+    if (this.baseCstVisitorConstructor === undefined) {
       const newBaseCstVisitorConstructor = createBaseSemanticVisitorConstructor(
         this.className,
-        keys(this.gastProductionsCache)
+        Object.keys(this.gastProductionsCache)
       )
       this.baseCstVisitorConstructor = newBaseCstVisitorConstructor
       return newBaseCstVisitorConstructor
@@ -248,10 +243,10 @@ export class TreeBuilder {
   ): {
     new (...args: any[]): ICstVisitor<IN, OUT>
   } {
-    if (isUndefined(this.baseCstVisitorWithDefaultsConstructor)) {
+    if (this.baseCstVisitorWithDefaultsConstructor === undefined) {
       const newConstructor = createBaseVisitorConstructorWithDefaults(
         this.className,
-        keys(this.gastProductionsCache),
+        Object.keys(this.gastProductionsCache),
         this.getBaseCstVisitorConstructor()
       )
       this.baseCstVisitorWithDefaultsConstructor = newConstructor

--- a/packages/chevrotain/src/scan/lexer.ts
+++ b/packages/chevrotain/src/scan/lexer.ts
@@ -1,27 +1,5 @@
 import { BaseRegExpVisitor } from "regexp-to-ast"
 import { IRegExpExec, Lexer, LexerDefinitionErrorType } from "./lexer_public"
-import first from "lodash/first"
-import isEmpty from "lodash/isEmpty"
-import compact from "lodash/compact"
-import isArray from "lodash/isArray"
-import values from "lodash/values"
-import flatten from "lodash/flatten"
-import reject from "lodash/reject"
-import difference from "lodash/difference"
-import indexOf from "lodash/indexOf"
-import map from "lodash/map"
-import forEach from "lodash/forEach"
-import isString from "lodash/isString"
-import isFunction from "lodash/isFunction"
-import isUndefined from "lodash/isUndefined"
-import find from "lodash/find"
-import has from "lodash/has"
-import keys from "lodash/keys"
-import isRegExp from "lodash/isRegExp"
-import filter from "lodash/filter"
-import defaults from "lodash/defaults"
-import reduce from "lodash/reduce"
-import includes from "lodash/includes"
 import { PRINT_ERROR } from "@chevrotain/utils"
 import {
   canMatchCharCode,
@@ -85,14 +63,14 @@ export function analyzeTokenTypes(
     tracer?: (msg: string, action: () => void) => void
   }
 ): IAnalyzeResult {
-  options = defaults(options, {
+  options = {
     useSticky: SUPPORT_STICKY,
-    debug: false as boolean,
-    safeMode: false as boolean,
+    safeMode: false,
     positionTracking: "full",
     lineTerminatorCharacters: ["\r", "\n"],
-    tracer: (msg: string, action: Function) => action()
-  })
+    tracer: (msg: string, action: Function) => action(),
+    ...options
+  }
 
   const tracer = options.tracer!
 
@@ -102,8 +80,8 @@ export function analyzeTokenTypes(
 
   let onlyRelevantTypes: TokenType[]
   tracer("Reject Lexer.NA", () => {
-    onlyRelevantTypes = reject(tokenTypes, (currType) => {
-      return currType[PATTERN] === Lexer.NA
+    onlyRelevantTypes = tokenTypes.filter((currType) => {
+      return currType[PATTERN] !== Lexer.NA
     })
   })
 
@@ -111,13 +89,12 @@ export function analyzeTokenTypes(
   let allTransformedPatterns: (IRegExpExec | string)[]
   tracer("Transform Patterns", () => {
     hasCustom = false
-    allTransformedPatterns = map(
-      onlyRelevantTypes,
+    allTransformedPatterns = onlyRelevantTypes.map(
       (currType): IRegExpExec | string => {
         const currPattern = currType[PATTERN]
 
         /* istanbul ignore else */
-        if (isRegExp(currPattern)) {
+        if (currPattern instanceof RegExp) {
           const regExpSource = currPattern.source
           if (
             regExpSource.length === 1 &&
@@ -132,27 +109,24 @@ export function analyzeTokenTypes(
             regExpSource.length === 2 &&
             regExpSource[0] === "\\" &&
             // not a meta character
-            !includes(
-              [
-                "d",
-                "D",
-                "s",
-                "S",
-                "t",
-                "r",
-                "n",
-                "t",
-                "0",
-                "c",
-                "b",
-                "B",
-                "f",
-                "v",
-                "w",
-                "W"
-              ],
-              regExpSource[1]
-            )
+            [
+              "d",
+              "D",
+              "s",
+              "S",
+              "t",
+              "r",
+              "n",
+              "t",
+              "0",
+              "c",
+              "b",
+              "B",
+              "f",
+              "v",
+              "w",
+              "W"
+            ].indexOf(regExpSource[1]) === -1
           ) {
             // escaped meta Characters: /\+/ /\[/
             // or redundant escaping: /\a/
@@ -163,7 +137,7 @@ export function analyzeTokenTypes(
               ? addStickyFlag(currPattern)
               : addStartOfInput(currPattern)
           }
-        } else if (isFunction(currPattern)) {
+        } else if (typeof currPattern === "function") {
           hasCustom = true
           // CustomPatternMatcherFunc - custom patterns do not require any transformations, only wrapping in a RegExp Like object
           return { exec: currPattern }
@@ -197,43 +171,41 @@ export function analyzeTokenTypes(
   let patternIdxToPushMode: (string | undefined)[]
   let patternIdxToPopMode: boolean[]
   tracer("misc mapping", () => {
-    patternIdxToType = map(
-      onlyRelevantTypes,
+    patternIdxToType = onlyRelevantTypes.map(
       (currType) => currType.tokenTypeIdx!
     )
 
-    patternIdxToGroup = map(onlyRelevantTypes, (clazz: any) => {
+    patternIdxToGroup = onlyRelevantTypes.map((clazz: any) => {
       const groupName = clazz.GROUP
       /* istanbul ignore next */
       if (groupName === Lexer.SKIPPED) {
         return undefined
-      } else if (isString(groupName)) {
+      } else if (typeof groupName === "string") {
         return groupName
-      } else if (isUndefined(groupName)) {
+      } else if (groupName === undefined) {
         return false
       } else {
         throw Error("non exhaustive match")
       }
     })
 
-    patternIdxToLongerAltIdxArr = map(onlyRelevantTypes, (clazz: any) => {
+    patternIdxToLongerAltIdxArr = onlyRelevantTypes.map((clazz: any) => {
       const longerAltType = clazz.LONGER_ALT
 
       if (longerAltType) {
-        const longerAltIdxArr = isArray(longerAltType)
-          ? map(longerAltType, (type: any) => indexOf(onlyRelevantTypes, type))
-          : [indexOf(onlyRelevantTypes, longerAltType)]
+        const longerAltIdxArr = Array.isArray(longerAltType)
+          ? longerAltType.map((type: any) => onlyRelevantTypes.indexOf(type))
+          : [onlyRelevantTypes.indexOf(longerAltType)]
         return longerAltIdxArr
       }
     })
 
-    patternIdxToPushMode = map(
-      onlyRelevantTypes,
+    patternIdxToPushMode = onlyRelevantTypes.map(
       (clazz: any) => clazz.PUSH_MODE
     )
 
-    patternIdxToPopMode = map(onlyRelevantTypes, (clazz: any) =>
-      has(clazz, "POP_MODE")
+    patternIdxToPopMode = onlyRelevantTypes.map((clazz: any) =>
+      clazz.hasOwnProperty("POP_MODE")
     )
   })
 
@@ -242,10 +214,10 @@ export function analyzeTokenTypes(
     const lineTerminatorCharCodes = getCharCodes(
       options.lineTerminatorCharacters!
     )
-    patternIdxToCanLineTerminator = map(onlyRelevantTypes, (tokType) => false)
+    patternIdxToCanLineTerminator = onlyRelevantTypes.map((tokType) => false)
     if (options.positionTracking !== "onlyOffset") {
-      patternIdxToCanLineTerminator = map(onlyRelevantTypes, (tokType) => {
-        if (has(tokType, "LINE_BREAKS")) {
+      patternIdxToCanLineTerminator = onlyRelevantTypes.map((tokType) => {
+        if (tokType.hasOwnProperty("LINE_BREAKS")) {
           return !!tokType.LINE_BREAKS
         } else {
           return (
@@ -265,23 +237,18 @@ export function analyzeTokenTypes(
   let emptyGroups!: { [groupName: string]: IToken[] }
   let patternIdxToConfig!: IPatternConfig[]
   tracer("Misc Mapping #2", () => {
-    patternIdxToIsCustom = map(onlyRelevantTypes, isCustomPattern)
-    patternIdxToShort = map(allTransformedPatterns, isShortPattern)
+    patternIdxToIsCustom = onlyRelevantTypes.map(isCustomPattern)
+    patternIdxToShort = allTransformedPatterns.map(isShortPattern)
 
-    emptyGroups = reduce(
-      onlyRelevantTypes,
-      (acc, clazz: any) => {
-        const groupName = clazz.GROUP
-        if (isString(groupName) && !(groupName === Lexer.SKIPPED)) {
-          acc[groupName] = []
-        }
-        return acc
-      },
-      {} as { [groupName: string]: IToken[] }
-    )
+    emptyGroups = onlyRelevantTypes.reduce((acc, clazz: any) => {
+      const groupName = clazz.GROUP
+      if (typeof groupName === "string" && !(groupName === Lexer.SKIPPED)) {
+        acc[groupName] = []
+      }
+      return acc
+    }, {} as { [groupName: string]: IToken[] })
 
-    patternIdxToConfig = map(
-      allTransformedPatterns,
+    patternIdxToConfig = allTransformedPatterns.map(
       (x, idx): IPatternConfig => {
         return {
           pattern: allTransformedPatterns[idx],
@@ -305,16 +272,15 @@ export function analyzeTokenTypes(
 
   if (!options.safeMode) {
     tracer("First Char Optimization", () => {
-      charCodeToPatternIdxToConfig = reduce(
-        onlyRelevantTypes,
+      charCodeToPatternIdxToConfig = onlyRelevantTypes.reduce(
         (result, currTokType, idx) => {
           if (typeof currTokType.PATTERN === "string") {
             const charCode = currTokType.PATTERN.charCodeAt(0)
             const optimizedIdx = charCodeToOptimizedIndex(charCode)
             addToMapOfArrays(result, optimizedIdx, patternIdxToConfig[idx])
-          } else if (isArray(currTokType.START_CHARS_HINT)) {
+          } else if (Array.isArray(currTokType.START_CHARS_HINT)) {
             let lastOptimizedIdx: number
-            forEach(currTokType.START_CHARS_HINT, (charOrInt) => {
+            currTokType.START_CHARS_HINT.forEach((charOrInt) => {
               const charCode =
                 typeof charOrInt === "string"
                   ? charOrInt.charCodeAt(0)
@@ -333,7 +299,7 @@ export function analyzeTokenTypes(
                 )
               }
             })
-          } else if (isRegExp(currTokType.PATTERN)) {
+          } else if (currTokType.PATTERN instanceof RegExp) {
             if (currTokType.PATTERN.unicode) {
               canBeOptimized = false
               if (options.ensureOptimizations) {
@@ -353,13 +319,13 @@ export function analyzeTokenTypes(
               /* istanbul ignore if */
               // start code will only be empty given an empty regExp or failure of regexp-to-ast library
               // the first should be a different validation and the second cannot be tested.
-              if (isEmpty(optimizedCodes)) {
+              if (optimizedCodes.length === 0) {
                 // we cannot understand what codes may start possible matches
                 // The optimization correctness requires knowing start codes for ALL patterns.
                 // Not actually sure this is an error, no debug message
                 canBeOptimized = false
               }
-              forEach(optimizedCodes, (code) => {
+              optimizedCodes.forEach((code) => {
                 addToMapOfArrays(result, code, patternIdxToConfig[idx])
               })
             }
@@ -421,8 +387,8 @@ function validateRegExpPattern(
   tokenTypes: TokenType[]
 ): ILexerDefinitionError[] {
   let errors: ILexerDefinitionError[] = []
-  const withRegExpPatterns = filter(tokenTypes, (currTokType) =>
-    isRegExp(currTokType[PATTERN])
+  const withRegExpPatterns = tokenTypes.filter(
+    (currTokType) => currTokType[PATTERN] instanceof RegExp
   )
 
   errors = errors.concat(findEndOfInputAnchor(withRegExpPatterns))
@@ -446,11 +412,11 @@ export interface ILexerFilterResult {
 export function findMissingPatterns(
   tokenTypes: TokenType[]
 ): ILexerFilterResult {
-  const tokenTypesWithMissingPattern = filter(tokenTypes, (currType) => {
-    return !has(currType, PATTERN)
+  const tokenTypesWithMissingPattern = tokenTypes.filter((currType) => {
+    return !currType.hasOwnProperty(PATTERN)
   })
 
-  const errors = map(tokenTypesWithMissingPattern, (currType) => {
+  const errors = tokenTypesWithMissingPattern.map((currType) => {
     return {
       message:
         "Token Type: ->" +
@@ -461,24 +427,26 @@ export function findMissingPatterns(
     }
   })
 
-  const valid = difference(tokenTypes, tokenTypesWithMissingPattern)
+  const valid = tokenTypes.filter(
+    (currType) => tokenTypesWithMissingPattern.indexOf(currType) === -1
+  )
   return { errors, valid }
 }
 
 export function findInvalidPatterns(
   tokenTypes: TokenType[]
 ): ILexerFilterResult {
-  const tokenTypesWithInvalidPattern = filter(tokenTypes, (currType) => {
+  const tokenTypesWithInvalidPattern = tokenTypes.filter((currType) => {
     const pattern = currType[PATTERN]
     return (
-      !isRegExp(pattern) &&
-      !isFunction(pattern) &&
-      !has(pattern, "exec") &&
-      !isString(pattern)
+      !(pattern instanceof RegExp) &&
+      !(typeof pattern === "function") &&
+      !pattern?.hasOwnProperty("exec") &&
+      !(typeof pattern === "string")
     )
   })
 
-  const errors = map(tokenTypesWithInvalidPattern, (currType) => {
+  const errors = tokenTypesWithInvalidPattern.map((currType) => {
     return {
       message:
         "Token Type: ->" +
@@ -490,7 +458,9 @@ export function findInvalidPatterns(
     }
   })
 
-  const valid = difference(tokenTypes, tokenTypesWithInvalidPattern)
+  const valid = tokenTypes.filter(
+    (currType) => tokenTypesWithInvalidPattern.indexOf(currType) === -1
+  )
   return { errors, valid }
 }
 
@@ -507,7 +477,7 @@ export function findEndOfInputAnchor(
     }
   }
 
-  const invalidRegex = filter(tokenTypes, (currType) => {
+  const invalidRegex = tokenTypes.filter((currType) => {
     const pattern = currType.PATTERN
 
     try {
@@ -523,7 +493,7 @@ export function findEndOfInputAnchor(
     }
   })
 
-  const errors = map(invalidRegex, (currType) => {
+  const errors = invalidRegex.map((currType) => {
     return {
       message:
         "Unexpected RegExp Anchor Error:\n" +
@@ -543,12 +513,12 @@ export function findEndOfInputAnchor(
 export function findEmptyMatchRegExps(
   tokenTypes: TokenType[]
 ): ILexerDefinitionError[] {
-  const matchesEmptyString = filter(tokenTypes, (currType) => {
+  const matchesEmptyString = tokenTypes.filter((currType) => {
     const pattern = currType.PATTERN as RegExp
     return pattern.test("")
   })
 
-  const errors = map(matchesEmptyString, (currType) => {
+  const errors = matchesEmptyString.map((currType) => {
     return {
       message:
         "Token Type: ->" +
@@ -575,7 +545,7 @@ export function findStartOfInputAnchor(
     }
   }
 
-  const invalidRegex = filter(tokenTypes, (currType) => {
+  const invalidRegex = tokenTypes.filter((currType) => {
     const pattern = currType.PATTERN as RegExp
     try {
       const regexpAst = getRegExpAst(pattern)
@@ -590,7 +560,7 @@ export function findStartOfInputAnchor(
     }
   })
 
-  const errors = map(invalidRegex, (currType) => {
+  const errors = invalidRegex.map((currType) => {
     return {
       message:
         "Unexpected RegExp Anchor Error:\n" +
@@ -610,12 +580,12 @@ export function findStartOfInputAnchor(
 export function findUnsupportedFlags(
   tokenTypes: TokenType[]
 ): ILexerDefinitionError[] {
-  const invalidFlags = filter(tokenTypes, (currType) => {
+  const invalidFlags = tokenTypes.filter((currType) => {
     const pattern = currType[PATTERN]
     return pattern instanceof RegExp && (pattern.multiline || pattern.global)
   })
 
-  const errors = map(invalidFlags, (currType) => {
+  const errors = invalidFlags.map((currType) => {
     return {
       message:
         "Token Type: ->" +
@@ -634,39 +604,35 @@ export function findDuplicatePatterns(
   tokenTypes: TokenType[]
 ): ILexerDefinitionError[] {
   const found: TokenType[] = []
-  let identicalPatterns = map(tokenTypes, (outerType: any) => {
-    return reduce(
-      tokenTypes,
-      (result, innerType) => {
-        if (
-          outerType.PATTERN.source === (innerType.PATTERN as RegExp).source &&
-          !includes(found, innerType) &&
-          innerType.PATTERN !== Lexer.NA
-        ) {
-          // this avoids duplicates in the result, each Token Type may only appear in one "set"
-          // in essence we are creating Equivalence classes on equality relation.
-          found.push(innerType)
-          result.push(innerType)
-          return result
-        }
+  let identicalPatterns = tokenTypes.map((outerType: any) => {
+    return tokenTypes.reduce((result, innerType) => {
+      if (
+        outerType.PATTERN.source === (innerType.PATTERN as RegExp).source &&
+        found.indexOf(innerType) === -1 &&
+        innerType.PATTERN !== Lexer.NA
+      ) {
+        // this avoids duplicates in the result, each Token Type may only appear in one "set"
+        // in essence we are creating Equivalence classes on equality relation.
+        found.push(innerType)
+        result.push(innerType)
         return result
-      },
-      [] as TokenType[]
-    )
+      }
+      return result
+    }, [] as TokenType[])
   })
 
-  identicalPatterns = compact(identicalPatterns)
+  identicalPatterns = identicalPatterns.filter((currPattern) => !!currPattern)
 
-  const duplicatePatterns = filter(identicalPatterns, (currIdenticalSet) => {
+  const duplicatePatterns = identicalPatterns.filter((currIdenticalSet) => {
     return currIdenticalSet.length > 1
   })
 
-  const errors = map(duplicatePatterns, (setOfIdentical: any) => {
-    const tokenTypeNames = map(setOfIdentical, (currType: any) => {
+  const errors = duplicatePatterns.map((setOfIdentical: any) => {
+    const tokenTypeNames = setOfIdentical.map((currType: any) => {
       return currType.name
     })
 
-    const dupPatternSrc = (<any>first(setOfIdentical)).PATTERN
+    const dupPatternSrc = setOfIdentical[0].PATTERN
     return {
       message:
         `The same RegExp pattern ->${dupPatternSrc}<-` +
@@ -684,16 +650,18 @@ export function findDuplicatePatterns(
 export function findInvalidGroupType(
   tokenTypes: TokenType[]
 ): ILexerDefinitionError[] {
-  const invalidTypes = filter(tokenTypes, (clazz: any) => {
-    if (!has(clazz, "GROUP")) {
+  const invalidTypes = tokenTypes.filter((clazz: any) => {
+    if (!clazz.hasOwnProperty("GROUP")) {
       return false
     }
     const group = clazz.GROUP
 
-    return group !== Lexer.SKIPPED && group !== Lexer.NA && !isString(group)
+    return (
+      group !== Lexer.SKIPPED && group !== Lexer.NA && typeof group !== "string"
+    )
   })
 
-  const errors = map(invalidTypes, (currType) => {
+  const errors = invalidTypes.map((currType) => {
     return {
       message:
         "Token Type: ->" +
@@ -711,13 +679,14 @@ export function findModesThatDoNotExist(
   tokenTypes: TokenType[],
   validModes: string[]
 ): ILexerDefinitionError[] {
-  const invalidModes = filter(tokenTypes, (clazz: any) => {
+  const invalidModes = tokenTypes.filter((clazz: any) => {
     return (
-      clazz.PUSH_MODE !== undefined && !includes(validModes, clazz.PUSH_MODE)
+      clazz.PUSH_MODE !== undefined &&
+      validModes.indexOf(clazz.PUSH_MODE) === -1
     )
   })
 
-  const errors = map(invalidModes, (tokType) => {
+  const errors = invalidModes.map((tokType) => {
     const msg =
       `Token Type: ->${tokType.name}<- static 'PUSH_MODE' value cannot refer to a Lexer Mode ->${tokType.PUSH_MODE}<-` +
       `which does not exist`
@@ -736,29 +705,25 @@ export function findUnreachablePatterns(
 ): ILexerDefinitionError[] {
   const errors: ILexerDefinitionError[] = []
 
-  const canBeTested = reduce(
-    tokenTypes,
-    (result, tokType, idx) => {
-      const pattern = tokType.PATTERN
+  const canBeTested = tokenTypes.reduce((result, tokType, idx) => {
+    const pattern = tokType.PATTERN
 
-      if (pattern === Lexer.NA) {
-        return result
-      }
-
-      // a more comprehensive validation for all forms of regExps would require
-      // deeper regExp analysis capabilities
-      if (isString(pattern)) {
-        result.push({ str: pattern, idx, tokenType: tokType })
-      } else if (isRegExp(pattern) && noMetaChar(pattern)) {
-        result.push({ str: pattern.source, idx, tokenType: tokType })
-      }
+    if (pattern === Lexer.NA) {
       return result
-    },
-    [] as { str: string; idx: number; tokenType: TokenType }[]
-  )
+    }
 
-  forEach(tokenTypes, (tokType, testIdx) => {
-    forEach(canBeTested, ({ str, idx, tokenType }) => {
+    // a more comprehensive validation for all forms of regExps would require
+    // deeper regExp analysis capabilities
+    if (typeof pattern === "string") {
+      result.push({ str: pattern, idx, tokenType: tokType })
+    } else if (pattern instanceof RegExp && noMetaChar(pattern)) {
+      result.push({ str: pattern.source, idx, tokenType: tokType })
+    }
+    return result
+  }, [] as { str: string; idx: number; tokenType: TokenType }[])
+
+  tokenTypes.forEach((tokType, testIdx) => {
+    canBeTested.forEach(({ str, idx, tokenType }) => {
       if (testIdx < idx && testTokenType(str, tokType.PATTERN)) {
         const msg =
           `Token: ->${tokenType.name}<- can never be matched.\n` +
@@ -779,13 +744,13 @@ export function findUnreachablePatterns(
 
 function testTokenType(str: string, pattern: any): boolean {
   /* istanbul ignore else */
-  if (isRegExp(pattern)) {
+  if (pattern instanceof RegExp) {
     const regExpArray = pattern.exec(str)
     return regExpArray !== null && regExpArray.index === 0
-  } else if (isFunction(pattern)) {
+  } else if (typeof pattern === "function") {
     // maintain the API of custom patterns
     return pattern(str, 0, [], {})
-  } else if (has(pattern, "exec")) {
+  } else if (pattern?.hasOwnProperty("exec")) {
     // maintain the API of custom patterns
     return pattern.exec(str, 0, [], {})
   } else if (typeof pattern === "string") {
@@ -812,9 +777,7 @@ function noMetaChar(regExp: RegExp): boolean {
     "+",
     "{"
   ]
-  return (
-    find(metaChars, (char) => regExp.source.indexOf(char) !== -1) === undefined
-  )
+  return !metaChars.some((char) => regExp.source.indexOf(char) !== -1)
 }
 
 export function addStartOfInput(pattern: RegExp): RegExp {
@@ -839,7 +802,7 @@ export function performRuntimeChecks(
   const errors: ILexerDefinitionError[] = []
 
   // some run time checks to help the end users.
-  if (!has(lexerDefinition, DEFAULT_MODE)) {
+  if (!lexerDefinition.hasOwnProperty(DEFAULT_MODE)) {
     errors.push({
       message:
         "A MultiMode Lexer cannot be initialized without a <" +
@@ -848,7 +811,7 @@ export function performRuntimeChecks(
       type: LexerDefinitionErrorType.MULTI_MODE_LEXER_WITHOUT_DEFAULT_MODE
     })
   }
-  if (!has(lexerDefinition, MODES)) {
+  if (!lexerDefinition.hasOwnProperty(MODES)) {
     errors.push({
       message:
         "A MultiMode Lexer cannot be initialized without a <" +
@@ -859,9 +822,9 @@ export function performRuntimeChecks(
   }
 
   if (
-    has(lexerDefinition, MODES) &&
-    has(lexerDefinition, DEFAULT_MODE) &&
-    !has(lexerDefinition.modes, lexerDefinition.defaultMode)
+    lexerDefinition.hasOwnProperty(MODES) &&
+    lexerDefinition.hasOwnProperty(DEFAULT_MODE) &&
+    !lexerDefinition.modes.hasOwnProperty(lexerDefinition.defaultMode)
   ) {
     errors.push({
       message:
@@ -871,34 +834,38 @@ export function performRuntimeChecks(
     })
   }
 
-  if (has(lexerDefinition, MODES)) {
-    forEach(lexerDefinition.modes, (currModeValue, currModeName) => {
-      forEach(currModeValue, (currTokType, currIdx) => {
-        if (isUndefined(currTokType)) {
-          errors.push({
-            message:
-              `A Lexer cannot be initialized using an undefined Token Type. Mode:` +
-              `<${currModeName}> at index: <${currIdx}>\n`,
-            type: LexerDefinitionErrorType.LEXER_DEFINITION_CANNOT_CONTAIN_UNDEFINED
-          })
-        } else if (has(currTokType, "LONGER_ALT")) {
-          const longerAlt = isArray(currTokType.LONGER_ALT)
-            ? currTokType.LONGER_ALT
-            : [currTokType.LONGER_ALT]
-          forEach(longerAlt, (currLongerAlt) => {
-            if (
-              !isUndefined(currLongerAlt) &&
-              !includes(currModeValue, currLongerAlt)
-            ) {
-              errors.push({
-                message: `A MultiMode Lexer cannot be initialized with a longer_alt <${currLongerAlt.name}> on token <${currTokType.name}> outside of mode <${currModeName}>\n`,
-                type: LexerDefinitionErrorType.MULTI_MODE_LEXER_LONGER_ALT_NOT_IN_CURRENT_MODE
-              })
-            }
-          })
-        }
-      })
-    })
+  if (lexerDefinition.hasOwnProperty(MODES)) {
+    Object.entries(lexerDefinition.modes).forEach(
+      ([currModeName, currModeValue]) => {
+        // Make currModeValue a non-sparse array
+        currModeValue = Array.from(currModeValue)
+        currModeValue.forEach((currTokType, currIdx) => {
+          if (currTokType === undefined) {
+            errors.push({
+              message:
+                `A Lexer cannot be initialized using an undefined Token Type. Mode:` +
+                `<${currModeName}> at index: <${currIdx}>\n`,
+              type: LexerDefinitionErrorType.LEXER_DEFINITION_CANNOT_CONTAIN_UNDEFINED
+            })
+          } else if (currTokType.hasOwnProperty("LONGER_ALT")) {
+            const longerAlt = Array.isArray(currTokType.LONGER_ALT)
+              ? currTokType.LONGER_ALT
+              : [currTokType.LONGER_ALT]
+            longerAlt.forEach((currLongerAlt) => {
+              if (
+                currLongerAlt !== undefined &&
+                currModeValue.indexOf(currLongerAlt) === -1
+              ) {
+                errors.push({
+                  message: `A MultiMode Lexer cannot be initialized with a longer_alt <${currLongerAlt.name}> on token <${currTokType.name}> outside of mode <${currModeName}>\n`,
+                  type: LexerDefinitionErrorType.MULTI_MODE_LEXER_LONGER_ALT_NOT_IN_CURRENT_MODE
+                })
+              }
+            })
+          }
+        })
+      }
+    )
   }
 
   return errors
@@ -911,15 +878,16 @@ export function performWarningRuntimeChecks(
 ): ILexerDefinitionError[] {
   const warnings = []
   let hasAnyLineBreak = false
-  const allTokenTypes = compact(flatten(values(lexerDefinition.modes)))
+  const allTokenTypes = ([] as TokenType[])
+    .concat(...Object.values(lexerDefinition.modes ?? {}))
+    .filter((tokType) => !!tokType)
 
-  const concreteTokenTypes = reject(
-    allTokenTypes,
-    (currType) => currType[PATTERN] === Lexer.NA
+  const concreteTokenTypes = allTokenTypes.filter(
+    (currType) => currType[PATTERN] !== Lexer.NA
   )
   const terminatorCharCodes = getCharCodes(lineTerminatorCharacters)
   if (trackLines) {
-    forEach(concreteTokenTypes, (tokType) => {
+    concreteTokenTypes.forEach((tokType) => {
       const currIssue = checkLineBreaksIssues(tokType, terminatorCharCodes)
       if (currIssue !== false) {
         const message = buildLineBreakIssueMessage(tokType, currIssue)
@@ -931,7 +899,7 @@ export function performWarningRuntimeChecks(
         warnings.push(warningDescriptor)
       } else {
         // we don't want to attempt to scan if the user explicitly specified the line_breaks option.
-        if (has(tokType, "LINE_BREAKS")) {
+        if (tokType.hasOwnProperty("LINE_BREAKS")) {
           if (tokType.LINE_BREAKS === true) {
             hasAnyLineBreak = true
           }
@@ -964,13 +932,13 @@ export function cloneEmptyGroups(emptyGroups: {
   [groupName: string]: IToken
 }): { [groupName: string]: IToken } {
   const clonedResult: any = {}
-  const groupKeys = keys(emptyGroups)
+  const groupKeys = Object.keys(emptyGroups)
 
-  forEach(groupKeys, (currKey) => {
+  groupKeys.forEach((currKey) => {
     const currGroupValue = emptyGroups[currKey]
 
     /* istanbul ignore else */
-    if (isArray(currGroupValue)) {
+    if (Array.isArray(currGroupValue)) {
       clonedResult[currKey] = []
     } else {
       throw Error("non exhaustive match")
@@ -984,15 +952,15 @@ export function cloneEmptyGroups(emptyGroups: {
 export function isCustomPattern(tokenType: TokenType): boolean {
   const pattern = tokenType.PATTERN
   /* istanbul ignore else */
-  if (isRegExp(pattern)) {
+  if (pattern instanceof RegExp) {
     return false
-  } else if (isFunction(pattern)) {
+  } else if (typeof pattern === "function") {
     // CustomPatternMatcherFunc - custom patterns do not require any transformations, only wrapping in a RegExp Like object
     return true
-  } else if (has(pattern, "exec")) {
+  } else if (pattern?.hasOwnProperty("exec")) {
     // ICustomPattern
     return true
-  } else if (isString(pattern)) {
+  } else if (typeof pattern === "string") {
     return false
   } else {
     throw Error("non exhaustive match")
@@ -1000,7 +968,7 @@ export function isCustomPattern(tokenType: TokenType): boolean {
 }
 
 export function isShortPattern(pattern: any): number | false {
-  if (isString(pattern) && pattern.length === 1) {
+  if (typeof pattern === "string" && pattern.length === 1) {
     return pattern.charCodeAt(0)
   } else {
     return false
@@ -1045,16 +1013,15 @@ function checkLineBreaksIssues(
       errMsg?: string
     }
   | false {
-  if (has(tokType, "LINE_BREAKS")) {
+  if (tokType.hasOwnProperty("LINE_BREAKS")) {
     // if the user explicitly declared the line_breaks option we will respect their choice
     // and assume it is correct.
     return false
   } else {
     /* istanbul ignore else */
-    if (isRegExp(tokType.PATTERN)) {
+    if (tokType.PATTERN instanceof RegExp) {
       try {
-        // TODO: why is the casting suddenly needed?
-        canMatchCharCode(lineTerminatorCharCodes, tokType.PATTERN as RegExp)
+        canMatchCharCode(lineTerminatorCharCodes, tokType.PATTERN)
       } catch (e) {
         /* istanbul ignore next - to test this we would have to mock <canMatchCharCode> to throw an error */
         return {
@@ -1063,7 +1030,7 @@ function checkLineBreaksIssues(
         }
       }
       return false
-    } else if (isString(tokType.PATTERN)) {
+    } else if (typeof tokType.PATTERN === "string") {
       // string literal patterns can always be analyzed to detect line terminator usage
       return false
     } else if (isCustomPattern(tokType)) {
@@ -1104,8 +1071,8 @@ export function buildLineBreakIssueMessage(
 }
 
 function getCharCodes(charsOrCodes: (number | string)[]): number[] {
-  const charCodes = map(charsOrCodes, (numOrString) => {
-    if (isString(numOrString)) {
+  const charCodes = charsOrCodes.map((numOrString) => {
+    if (typeof numOrString === "string") {
       return numOrString.charCodeAt(0)
     } else {
       return numOrString
@@ -1160,7 +1127,7 @@ export function charCodeToOptimizedIndex(charCode: number): number {
  * TODO: Perhaps it should be lazy initialized only if a charCode > 255 is used.
  */
 function initCharCodeToOptimizedIndexMap() {
-  if (isEmpty(charCodeToOptimizedIdxMap)) {
+  if (charCodeToOptimizedIdxMap.length === 0) {
     charCodeToOptimizedIdxMap = new Array(65536)
     for (let i = 0; i < 65536; i++) {
       charCodeToOptimizedIdxMap[i] = i > 255 ? 255 + ~~(i / 255) : i

--- a/packages/chevrotain/src/scan/lexer_public.ts
+++ b/packages/chevrotain/src/scan/lexer_public.ts
@@ -11,19 +11,6 @@ import {
   SUPPORT_STICKY,
   validatePatterns
 } from "./lexer"
-import noop from "lodash/noop"
-import isEmpty from "lodash/isEmpty"
-import isArray from "lodash/isArray"
-import last from "lodash/last"
-import reject from "lodash/reject"
-import map from "lodash/map"
-import forEach from "lodash/forEach"
-import keys from "lodash/keys"
-import isUndefined from "lodash/isUndefined"
-import identity from "lodash/identity"
-import assign from "lodash/assign"
-import reduce from "lodash/reduce"
-import clone from "lodash/clone"
 import { PRINT_WARNING, timer, toFastProperties } from "@chevrotain/utils"
 import { augmentTokenTypes } from "./tokens"
 import {
@@ -125,7 +112,7 @@ export class Lexer {
     }
 
     // todo: defaults func?
-    this.config = assign({}, DEFAULT_LEXER_CONFIG, config) as any
+    this.config = Object.assign({}, DEFAULT_LEXER_CONFIG, config)
 
     const traceInitVal = this.config.traceInitPerf
     if (traceInitVal === true) {
@@ -171,15 +158,15 @@ export class Lexer {
         this.trackEndLines = /full/i.test(this.config.positionTracking)
 
         // Convert SingleModeLexerDefinition into a IMultiModeLexerDefinition.
-        if (isArray(lexerDefinition)) {
+        if (Array.isArray(lexerDefinition)) {
           actualDefinition = {
-            modes: { defaultMode: clone(lexerDefinition) },
+            modes: { defaultMode: lexerDefinition.slice() },
             defaultMode: DEFAULT_MODE
           }
         } else {
           // no conversion needed, input should already be a IMultiModeLexerDefinition
           hasOnlySingleMode = false
-          actualDefinition = clone(<IMultiModeLexerDefinition>lexerDefinition)
+          actualDefinition = Object.assign({}, lexerDefinition)
         }
       })
 
@@ -212,18 +199,18 @@ export class Lexer {
 
       // an error of undefined TokenTypes will be detected in "performRuntimeChecks" above.
       // this transformation is to increase robustness in the case of partially invalid lexer definition.
-      forEach(actualDefinition.modes, (currModeValue, currModeName) => {
-        actualDefinition.modes[currModeName] = reject<TokenType>(
-          currModeValue,
-          (currTokType) => isUndefined(currTokType)
-        )
-      })
+      Object.entries(actualDefinition.modes).forEach(
+        ([currModeName, currModeValue]) => {
+          actualDefinition.modes[currModeName] = currModeValue.filter(
+            (currTokType) => currTokType !== undefined
+          )
+        }
+      )
 
-      const allModeNames = keys(actualDefinition.modes)
+      const allModeNames = Object.keys(actualDefinition.modes)
 
-      forEach(
-        actualDefinition.modes,
-        (currModDef: TokenType[], currModName) => {
+      Object.entries(actualDefinition.modes).forEach(
+        ([currModName, currModDef]) => {
           this.TRACE_INIT(`Mode: <${currModName}> processing`, () => {
             this.modes.push(currModName)
 
@@ -238,7 +225,7 @@ export class Lexer {
             // If definition errors were encountered, the analysis phase may fail unexpectedly/
             // Considering a lexer with definition errors may never be used, there is no point
             // to performing the analysis anyhow...
-            if (isEmpty(this.lexerDefinitionErrors)) {
+            if (this.lexerDefinitionErrors.length === 0) {
               augmentTokenTypes(currModDef)
 
               let currAnalyzeResult!: IAnalyzeResult
@@ -259,7 +246,7 @@ export class Lexer {
               this.charCodeToPatternIdxToConfig[currModName] =
                 currAnalyzeResult.charCodeToPatternIdxToConfig
 
-              this.emptyGroups = assign(
+              this.emptyGroups = Object.assign(
                 {},
                 this.emptyGroups,
                 currAnalyzeResult.emptyGroups
@@ -277,10 +264,10 @@ export class Lexer {
       this.defaultMode = actualDefinition.defaultMode
 
       if (
-        !isEmpty(this.lexerDefinitionErrors) &&
+        this.lexerDefinitionErrors.length > 0 &&
         !this.config.deferDefinitionErrorsHandling
       ) {
-        const allErrMessages = map(this.lexerDefinitionErrors, (error) => {
+        const allErrMessages = this.lexerDefinitionErrors.map((error) => {
           return error.message
         })
         const allErrMessagesString = allErrMessages.join(
@@ -292,7 +279,7 @@ export class Lexer {
       }
 
       // Only print warning if there are no errors, This will avoid pl
-      forEach(this.lexerDefinitionWarning, (warningDescriptor) => {
+      this.lexerDefinitionWarning.forEach((warningDescriptor) => {
         PRINT_WARNING(warningDescriptor.message)
       })
 
@@ -301,23 +288,23 @@ export class Lexer {
         // These implementations should be in-lined by the JavaScript engine
         // to provide optimal performance in each scenario.
         if (SUPPORT_STICKY) {
-          this.chopInput = <any>identity
+          this.chopInput = (text) => text
           this.match = this.matchWithTest
         } else {
-          this.updateLastIndex = noop
+          this.updateLastIndex = () => {}
           this.match = this.matchWithExec
         }
 
         if (hasOnlySingleMode) {
-          this.handleModes = noop
+          this.handleModes = () => {}
         }
 
         if (this.trackStartLines === false) {
-          this.computeNewColumn = identity
+          this.computeNewColumn = (col) => col
         }
 
         if (this.trackEndLines === false) {
-          this.updateTokenEndLineColumnLocation = noop
+          this.updateTokenEndLineColumnLocation = () => {}
         }
 
         if (/full/i.test(this.config.positionTracking)) {
@@ -342,18 +329,11 @@ export class Lexer {
       })
 
       this.TRACE_INIT("Failed Optimization Warnings", () => {
-        const unOptimizedModes = reduce(
-          this.canModeBeOptimized,
-          (cannotBeOptimized, canBeOptimized, modeName) => {
-            if (canBeOptimized === false) {
-              cannotBeOptimized.push(modeName)
-            }
-            return cannotBeOptimized
-          },
-          [] as string[]
+        const unOptimizedModes = Object.keys(this.canModeBeOptimized).filter(
+          (modeName) => !this.canModeBeOptimized[modeName]
         )
 
-        if (config.ensureOptimizations && !isEmpty(unOptimizedModes)) {
+        if (config.ensureOptimizations && unOptimizedModes.length > 0) {
           throw Error(
             `Lexer Modes: < ${unOptimizedModes.join(
               ", "
@@ -378,8 +358,8 @@ export class Lexer {
     text: string,
     initialMode: string = this.defaultMode
   ): ILexingResult {
-    if (!isEmpty(this.lexerDefinitionErrors)) {
-      const allErrMessages = map(this.lexerDefinitionErrors, (error) => {
+    if (this.lexerDefinitionErrors.length > 0) {
+      const allErrMessages = this.lexerDefinitionErrors.map((error) => {
         return error.message
       })
       const allErrMessagesString = allErrMessages.join(
@@ -485,7 +465,7 @@ export class Lexer {
         })
       } else {
         modeStack.pop()
-        const newMode = last(modeStack)!
+        const newMode = modeStack[modeStack.length - 1]
         patternIdxToConfig = this.patternIdxToConfig[newMode]
         currCharCodeToPatternIdxToConfig =
           this.charCodeToPatternIdxToConfig[newMode]

--- a/packages/chevrotain/src/scan/reg_exp.ts
+++ b/packages/chevrotain/src/scan/reg_exp.ts
@@ -9,12 +9,6 @@ import {
   Term,
   VERSION
 } from "regexp-to-ast"
-import isArray from "lodash/isArray"
-import every from "lodash/every"
-import forEach from "lodash/forEach"
-import find from "lodash/find"
-import values from "lodash/values"
-import includes from "lodash/includes"
 import { PRINT_ERROR, PRINT_WARNING } from "@chevrotain/utils"
 import { ASTNode, getRegExpAst } from "./reg_exp_parser"
 import { charCodeToOptimizedIndex, minOptimizationVal } from "./lexer"
@@ -111,7 +105,7 @@ export function firstCharOptimizedIndices(
             if (atom.complement === true) {
               throw Error(complementErrorMessage)
             }
-            forEach(atom.value, (code) => {
+            atom.value.forEach((code) => {
               if (typeof code === "number") {
                 addOptimizedIdxToResult(code, result, ignoreCase)
               } else {
@@ -188,7 +182,7 @@ export function firstCharOptimizedIndices(
   }
 
   // console.log(Object.keys(result).length)
-  return values(result)
+  return Object.values(result)
 }
 
 function addOptimizedIdxToResult(
@@ -224,17 +218,14 @@ function handleIgnoreCase(
 }
 
 function findCode(setNode: Set, targetCharCodes: number[]) {
-  return find(setNode.value, (codeOrRange) => {
+  return setNode.value.find((codeOrRange) => {
     if (typeof codeOrRange === "number") {
-      return includes(targetCharCodes, codeOrRange)
+      return targetCharCodes.indexOf(codeOrRange) !== -1
     } else {
       // range
       const range = <any>codeOrRange
-      return (
-        find(
-          targetCharCodes,
-          (targetCode) => range.from <= targetCode && targetCode <= range.to
-        ) !== undefined
+      return targetCharCodes.some(
+        (targetCode) => range.from <= targetCode && targetCode <= range.to
       )
     }
   })
@@ -250,8 +241,8 @@ function isWholeOptional(ast: any): boolean {
     return false
   }
 
-  return isArray(ast.value)
-    ? every(ast.value, isWholeOptional)
+  return Array.isArray(ast.value)
+    ? ast.value.every(isWholeOptional)
     : isWholeOptional(ast.value)
 }
 
@@ -283,7 +274,7 @@ class CharCodeFinder extends BaseRegExpVisitor {
   }
 
   visitCharacter(node: Character) {
-    if (includes(this.targetCharCodes, node.value)) {
+    if (this.targetCharCodes.indexOf(node.value) !== -1) {
       this.found = true
     }
   }
@@ -311,10 +302,8 @@ export function canMatchCharCode(
     charCodeFinder.visit(ast)
     return charCodeFinder.found
   } else {
-    return (
-      find(<any>pattern, (char) => {
-        return includes(charCodes, (<string>char).charCodeAt(0))
-      }) !== undefined
+    return Array.from(pattern).some(
+      (char) => charCodes.indexOf(char.charCodeAt(0)) !== -1
     )
   }
 }

--- a/packages/chevrotain/src/scan/tokens_public.ts
+++ b/packages/chevrotain/src/scan/tokens_public.ts
@@ -1,6 +1,3 @@
-import isString from "lodash/isString"
-import has from "lodash/has"
-import isUndefined from "lodash/isUndefined"
 import { Lexer } from "./lexer_public"
 import { augmentTokenTypes, tokenStructuredMatcher } from "./tokens"
 import { IToken, ITokenConfig, TokenType } from "@chevrotain/types"
@@ -20,7 +17,7 @@ export function tokenName(tokType: TokenType): string {
 export function hasTokenLabel(
   obj: TokenType
 ): obj is TokenType & Pick<Required<TokenType>, "LABEL"> {
-  return isString(obj.LABEL) && obj.LABEL !== ""
+  return typeof obj.LABEL === "string" && obj.LABEL !== ""
 }
 
 const PARENT = "parent"
@@ -43,49 +40,49 @@ function createTokenInternal(config: ITokenConfig): TokenType {
   const tokenType: TokenType = <any>{}
   tokenType.name = config.name
 
-  if (!isUndefined(pattern)) {
+  if (pattern !== undefined) {
     tokenType.PATTERN = pattern
   }
 
-  if (has(config, PARENT)) {
+  if (config.hasOwnProperty(PARENT)) {
     throw (
       "The parent property is no longer supported.\n" +
       "See: https://github.com/chevrotain/chevrotain/issues/564#issuecomment-349062346 for details."
     )
   }
 
-  if (has(config, CATEGORIES)) {
+  if (config.hasOwnProperty(CATEGORIES)) {
     // casting to ANY as this will be fixed inside `augmentTokenTypes``
     tokenType.CATEGORIES = <any>config[CATEGORIES]
   }
 
   augmentTokenTypes([tokenType])
 
-  if (has(config, LABEL)) {
+  if (config.hasOwnProperty(LABEL)) {
     tokenType.LABEL = config[LABEL]
   }
 
-  if (has(config, GROUP)) {
+  if (config.hasOwnProperty(GROUP)) {
     tokenType.GROUP = config[GROUP]
   }
 
-  if (has(config, POP_MODE)) {
+  if (config.hasOwnProperty(POP_MODE)) {
     tokenType.POP_MODE = config[POP_MODE]
   }
 
-  if (has(config, PUSH_MODE)) {
+  if (config.hasOwnProperty(PUSH_MODE)) {
     tokenType.PUSH_MODE = config[PUSH_MODE]
   }
 
-  if (has(config, LONGER_ALT)) {
+  if (config.hasOwnProperty(LONGER_ALT)) {
     tokenType.LONGER_ALT = config[LONGER_ALT]
   }
 
-  if (has(config, LINE_BREAKS)) {
+  if (config.hasOwnProperty(LINE_BREAKS)) {
     tokenType.LINE_BREAKS = config[LINE_BREAKS]
   }
 
-  if (has(config, START_CHARS_HINT)) {
+  if (config.hasOwnProperty(START_CHARS_HINT)) {
     tokenType.START_CHARS_HINT = config[START_CHARS_HINT]
   }
 

--- a/packages/chevrotain/test/full_flow/backtracking/backtracking_parser_spec.ts
+++ b/packages/chevrotain/test/full_flow/backtracking/backtracking_parser_spec.ts
@@ -12,7 +12,6 @@ import {
   RET_TYPE,
   SemiColonTok
 } from "./backtracking_parser"
-import flatten from "lodash/flatten"
 import { createRegularToken } from "../../utils/matchers"
 
 describe("Simple backtracking example", () => {
@@ -50,7 +49,7 @@ describe("Simple backtracking example", () => {
   })
 
   it("can parse an element with Equals and a very long qualified name", () => {
-    const input: any = flatten([
+    const input = ([] as any[]).concat(
       // element A:ns1.ns2.ns3.ns4.ns5.ns6.ns7.ns8.ns9.ns10.ns11.ns12 = 666;
       createRegularToken(ElementTok, "element"),
       createRegularToken(IdentTok, "A"),
@@ -59,7 +58,7 @@ describe("Simple backtracking example", () => {
       createRegularToken(EqualsTok, "="),
       createRegularToken(NumberTok, "666"),
       createRegularToken(SemiColonTok, ";")
-    ])
+    )
 
     const parser = new BackTrackingParser()
     parser.input = input
@@ -70,7 +69,7 @@ describe("Simple backtracking example", () => {
   })
 
   it("can parse an element with Default and a very long qualified name", () => {
-    const input: any = flatten([
+    const input = ([] as any[]).concat(
       // element A:ns1.ns2.ns3.ns4.ns5.ns6.ns7.ns8.ns9.ns10.ns11.ns12 default 666;
       createRegularToken(ElementTok, "element"),
       createRegularToken(IdentTok, "A"),
@@ -79,7 +78,7 @@ describe("Simple backtracking example", () => {
       createRegularToken(DefaultTok, "deafult"),
       createRegularToken(NumberTok, "666"),
       createRegularToken(SemiColonTok, ";")
-    ])
+    )
 
     const parser = new BackTrackingParser()
     parser.input = input

--- a/packages/chevrotain/test/full_flow/ecma_quirks/ecma_quirks.ts
+++ b/packages/chevrotain/test/full_flow/ecma_quirks/ecma_quirks.ts
@@ -4,10 +4,6 @@ import { EmbeddedActionsParser } from "../../../src/parse/parser/traits/parser_t
 
 import { END_OF_FILE } from "../../../src/parse/parser/parser"
 import { MismatchedTokenException } from "../../../src/parse/exceptions_public"
-import flatten from "lodash/flatten"
-import every from "lodash/every"
-import map from "lodash/map"
-import forEach from "lodash/forEach"
 import {
   ILookaheadStrategy,
   ILookaheadValidationError,
@@ -76,7 +72,7 @@ function deferredInitTokens() {
   // Avoids errors in browser tests where the bundled specs will execute this
   // file even if the tests will avoid running it.
   if (typeof (<any>new RegExp("(?:)")).sticky === "boolean") {
-    forEach(allTokens, (currTokType) => {
+    Object.values(allTokens).forEach((currTokType) => {
       currTokType.PATTERN = new RegExp(
         (currTokType.PATTERN as RegExp).source,
         "y"
@@ -115,14 +111,16 @@ class EcmaScriptQuirksLookaheadStrategy implements ILookaheadStrategy {
     })
 
     if (
-      !every(alts, (currPath) =>
-        every(currPath, (currAlt) => currAlt.length === 1)
+      !alts.every((currPath) =>
+        currPath.every((currAlt) => currAlt.length === 1)
       )
     ) {
       throw Error("This scannerLess parser only supports LL(1) lookahead.")
     }
 
-    const allTokenTypesPerAlt = map(alts, flatten)
+    const allTokenTypesPerAlt = alts.map((currPath) =>
+      ([] as TokenType[]).concat(...currPath)
+    )
 
     return function (this: EcmaScriptQuirksParser) {
       // save & restore lexer state as otherwise the text index will move ahead
@@ -162,11 +160,11 @@ class EcmaScriptQuirksLookaheadStrategy implements ILookaheadStrategy {
       prodType: options.prodType
     })[0]
 
-    if (!every(alt, (currAlt) => currAlt.length === 1)) {
+    if (!alt.every((currAlt) => currAlt.length === 1)) {
       throw Error("This scannerLess parser only supports LL(1) lookahead.")
     }
 
-    const allTokenTypes = flatten(alt)
+    const allTokenTypes = ([] as TokenType[]).concat(...alt)
 
     return function (this: EcmaScriptQuirksParser) {
       // save & restore lexer state as otherwise the text index will move ahead

--- a/packages/chevrotain/test/full_flow/error_recovery/sql_statements/sql_recovery_parser.ts
+++ b/packages/chevrotain/test/full_flow/error_recovery/sql_statements/sql_recovery_parser.ts
@@ -5,7 +5,6 @@
  * INSERT (32, "SHAHAR") INTO schema2.Persons
  * DELETE (31, "SHAHAR") FROM schema2.Persons
  */
-import values from "lodash/values"
 import { EmbeddedActionsParser } from "../../../../src/parse/parser/traits/parser_traits"
 import * as allTokens from "./sql_recovery_tokens"
 import {
@@ -46,7 +45,7 @@ import { IToken, TokenType } from "@chevrotain/types"
 // deferred execution to only run "inside" a test
 function initTokens() {
   const allTokensToUse = { ...allTokens }
-  augmentTokenTypes(values(allTokensToUse))
+  augmentTokenTypes(Object.values(allTokensToUse))
   return allTokensToUse
 }
 

--- a/packages/chevrotain/test/full_flow/error_recovery/sql_statements/sql_recovery_spec.ts
+++ b/packages/chevrotain/test/full_flow/error_recovery/sql_statements/sql_recovery_spec.ts
@@ -27,7 +27,6 @@ import { DDLExampleRecoveryParser } from "./sql_recovery_parser"
 import { tokenMatcher } from "../../../../src/scan/tokens_public"
 import { NotAllInputParsedException } from "../../../../src/parse/exceptions_public"
 import { ParseTree } from "../../parse_tree"
-import flatten from "lodash/flatten"
 import { createRegularToken } from "../../../utils/matchers"
 import { IToken } from "@chevrotain/types"
 
@@ -59,7 +58,7 @@ describe("Error Recovery SQL DDL Example", () => {
   })
 
   it("can parse a series of three statements successfully", () => {
-    const input: any = flatten([
+    const input = ([] as any[]).concat(
       // CREATE TABLE schema2.Persons
       createRegularToken(CreateTok),
       createRegularToken(TableTok),
@@ -77,7 +76,7 @@ describe("Error Recovery SQL DDL Example", () => {
       createRegularToken(FromTok),
       schemaFQN,
       createRegularToken(SemiColonTok)
-    ])
+    )
 
     const parser = new DDLExampleRecoveryParser()
     parser.input = input
@@ -90,7 +89,7 @@ describe("Error Recovery SQL DDL Example", () => {
     let input: IToken[]
 
     before(() => {
-      input = flatten([
+      input = ([] as any[]).concat(
         // CREATE TABLE schema2.Persons
         createRegularToken(CreateTok),
         createRegularToken(TableTok),
@@ -107,7 +106,7 @@ describe("Error Recovery SQL DDL Example", () => {
         createRegularToken(FromTok),
         schemaFQN,
         createRegularToken(SemiColonTok)
-      ])
+      )
     })
 
     it("can perform single token insertion for a missing semicolon", () => {
@@ -139,7 +138,7 @@ describe("Error Recovery SQL DDL Example", () => {
     let input: IToken[]
 
     before(() => {
-      input = flatten([
+      input = ([] as any[]).concat(
         // CREATE TABLE schema2.Persons
         createRegularToken(CreateTok),
         createRegularToken(TableTok),
@@ -158,7 +157,7 @@ describe("Error Recovery SQL DDL Example", () => {
         createRegularToken(FromTok),
         schemaFQN,
         createRegularToken(SemiColonTok)
-      ])
+      )
     })
 
     it("can perform single token deletion for a redundant keyword", () => {
@@ -195,7 +194,7 @@ describe("Error Recovery SQL DDL Example", () => {
         createRegularToken(LParenTok)
       ]
 
-      input = flatten([
+      input = ([] as any[]).concat(
         // CREATE TABLE schema2.Persons
         createRegularToken(CreateTok),
         createRegularToken(TableTok),
@@ -215,11 +214,11 @@ describe("Error Recovery SQL DDL Example", () => {
         createRegularToken(FromTok),
         schemaFQN,
         createRegularToken(SemiColonTok)
-      ])
+      )
     })
 
     it("can perform re-sync recovery and only 'lose' part of the input", () => {
-      const input: any = flatten([
+      const input = ([] as any[]).concat(
         // CREATE TABLE schema2.Persons
         createRegularToken(CreateTok),
         createRegularToken(TableTok),
@@ -239,7 +238,7 @@ describe("Error Recovery SQL DDL Example", () => {
         createRegularToken(FromTok),
         schemaFQN,
         createRegularToken(SemiColonTok)
-      ])
+      )
 
       const parser = new DDLExampleRecoveryParser()
       parser.input = input
@@ -322,14 +321,14 @@ describe("Error Recovery SQL DDL Example", () => {
   }
 
   it("will encounter an NotAllInputParsedException when some of the input vector has not been parsed", () => {
-    const input: any = flatten([
+    const input = ([] as any[]).concat(
       // CREATE TABLE schema2.Persons; TABLE <-- redundant "TABLE" token
       createRegularToken(CreateTok),
       createRegularToken(TableTok),
       schemaFQN,
       createRegularToken(SemiColonTok),
       createRegularToken(TableTok)
-    ])
+    )
     const parser = new DDLExampleRecoveryParser()
     parser.input = input
 
@@ -339,25 +338,26 @@ describe("Error Recovery SQL DDL Example", () => {
   })
 
   it("can use the same parser instance to parse multiple inputs", () => {
-    const input1: any = flatten([
+    const input1 = ([] as any[]).concat(
       // CREATE TABLE schema2.Persons;
       createRegularToken(CreateTok),
       createRegularToken(TableTok),
       schemaFQN,
       createRegularToken(SemiColonTok)
-    ])
-    const parser = new DDLExampleRecoveryParser(input1)
+    )
+    const parser = new DDLExampleRecoveryParser()
+    parser.input = input1
     parser.ddl()
     expect(parser.errors.length).to.equal(0)
 
-    const input2: any = flatten([
+    const input2 = ([] as any[]).concat(
       // DELETE (31, "SHAHAR") FROM schema2.Persons
       createRegularToken(DeleteTok),
       shahar31Record,
       createRegularToken(FromTok),
       schemaFQN,
       createRegularToken(SemiColonTok)
-    ])
+    )
     // the parser is being reset instead of creating a new instance for each new input
     parser.reset()
     parser.input = input2
@@ -373,7 +373,7 @@ describe("Error Recovery SQL DDL Example", () => {
   })
 
   it("can re-sync to the next iteration in a MANY rule", () => {
-    const input: any = flatten([
+    const input = ([] as any[]).concat(
       // CREATE TABLE schema2.Persons
       createRegularToken(CreateTok),
       createRegularToken(TableTok),
@@ -393,7 +393,7 @@ describe("Error Recovery SQL DDL Example", () => {
       createRegularToken(FromTok),
       schemaFQN,
       createRegularToken(SemiColonTok)
-    ])
+    )
 
     const parser = new DDLExampleRecoveryParser()
     parser.input = input

--- a/packages/chevrotain/test/full_flow/error_recovery/switch_case/switchcase_recovery_parser.ts
+++ b/packages/chevrotain/test/full_flow/error_recovery/switch_case/switchcase_recovery_parser.ts
@@ -44,8 +44,6 @@ import {
   StringTok,
   SwitchTok
 } from "./switchcase_recovery_tokens"
-import assign from "lodash/assign"
-import includes from "lodash/includes"
 import { IToken, TokenType } from "@chevrotain/types"
 
 export interface RetType {
@@ -83,9 +81,8 @@ export class SwitchCaseRecoveryParser extends EmbeddedActionsParser {
   // DOCS: overriding this method allows us to customize the logic for which tokens may not be automatically inserted
   // during error recovery.
   public canTokenTypeBeInsertedInRecovery(tokType: TokenType) {
-    return !includes(
-      this.tokTypesThatCannotBeInsertedInRecovery,
-      tokType as unknown
+    return (
+      this.tokTypesThatCannotBeInsertedInRecovery.indexOf(tokType as any) === -1
     )
   }
 
@@ -112,7 +109,7 @@ export class SwitchCaseRecoveryParser extends EmbeddedActionsParser {
     this.CONSUME(LCurlyTok)
 
     this.AT_LEAST_ONE(() => {
-      assign(retObj, this.SUBRULE(this.caseStmt))
+      Object.assign(retObj, this.SUBRULE(this.caseStmt))
     })
 
     this.CONSUME(RCurlyTok)

--- a/packages/chevrotain/test/full_flow/parse_tree.ts
+++ b/packages/chevrotain/test/full_flow/parse_tree.ts
@@ -1,6 +1,3 @@
-import compact from "lodash/compact"
-import isFunction from "lodash/isFunction"
-import isUndefined from "lodash/isUndefined"
 import { IToken, TokenType } from "@chevrotain/types"
 
 export class ParseTree {
@@ -31,13 +28,13 @@ export function PT(
   tokenOrTokenClass: TokenType | IToken,
   children: ParseTree[] = []
 ): ParseTree | null {
-  const childrenCompact = compact(children)
+  const childrenCompact = children.filter((child) => !!child)
 
   if ((<IToken>tokenOrTokenClass).image !== undefined) {
     return new ParseTree(<IToken>tokenOrTokenClass, childrenCompact)
-  } else if (isFunction(tokenOrTokenClass)) {
+  } else if (typeof tokenOrTokenClass === "function") {
     return new ParseTree(new (<any>tokenOrTokenClass)(), childrenCompact)
-  } else if (isUndefined(tokenOrTokenClass) || tokenOrTokenClass === null) {
+  } else if (tokenOrTokenClass === undefined || tokenOrTokenClass === null) {
     return null
   } else {
     throw `Invalid parameter ${tokenOrTokenClass} to PT factory.`

--- a/packages/chevrotain/test/parse/cst_spec.ts
+++ b/packages/chevrotain/test/parse/cst_spec.ts
@@ -2,12 +2,11 @@ import { createToken } from "../../src/scan/tokens_public"
 import { CstParser } from "../../src/parse/parser/traits/parser_traits"
 import { tokenStructuredMatcher as tokenStructuredMatcherStrict } from "../../src/scan/tokens"
 import { createRegularToken } from "../utils/matchers"
-import map from "lodash/map"
 import { CstElement, CstNode, IToken, TokenType } from "@chevrotain/types"
 import { expect } from "chai"
 
 function createTokenVector(tokTypes: TokenType[]): any[] {
-  return map(tokTypes, (curTokType) => {
+  return tokTypes.map((curTokType) => {
     return createRegularToken(curTokType)
   })
 }

--- a/packages/chevrotain/test/parse/cst_visitor_spec.ts
+++ b/packages/chevrotain/test/parse/cst_visitor_spec.ts
@@ -1,7 +1,6 @@
 import { createToken } from "../../src/scan/tokens_public"
 import { CstParser } from "../../src/parse/parser/traits/parser_traits"
 import { createRegularToken } from "../utils/matchers"
-import keys from "lodash/keys"
 import { IToken, TokenType } from "@chevrotain/types"
 import { expect } from "chai"
 
@@ -63,12 +62,12 @@ describe("The CSTVisitor", () => {
       }
 
       testRule(ctx: any) {
-        expect(keys(ctx)).to.deep.equal(["A", "B", "bamba"])
+        expect(Object.keys(ctx)).to.deep.equal(["A", "B", "bamba"])
         return this.visit(ctx.bamba[0])
       }
 
       bamba(ctx: any) {
-        expect(keys(ctx)).to.deep.equal(["C"])
+        expect(Object.keys(ctx)).to.deep.equal(["C"])
         return 666
       }
     }
@@ -93,14 +92,14 @@ describe("The CSTVisitor", () => {
       }
 
       testRule(ctx: any, param: any) {
-        expect(keys(ctx)).to.deep.equal(["A", "B", "bamba"])
+        expect(Object.keys(ctx)).to.deep.equal(["A", "B", "bamba"])
         return this.visit(ctx.bamba[0], param)
       }
 
       bamba(ctx: any, param: any) {
         // inspecting handling of optional arguments
         expect(this.visit(ctx.missingKey)).to.be.undefined
-        expect(keys(ctx)).to.deep.equal(["C"])
+        expect(Object.keys(ctx)).to.deep.equal(["C"])
         return 666 + param
       }
     }
@@ -126,7 +125,7 @@ describe("The CSTVisitor", () => {
       }
 
       bamba(ctx: any) {
-        expect(keys(ctx)).to.deep.equal(["C"])
+        expect(Object.keys(ctx)).to.deep.equal(["C"])
         visited = true
       }
     }
@@ -152,12 +151,12 @@ describe("The CSTVisitor", () => {
       }
 
       testRule(ctx: any, param: any) {
-        expect(keys(ctx)).to.deep.equal(["A", "B", "bamba"])
+        expect(Object.keys(ctx)).to.deep.equal(["A", "B", "bamba"])
         return this.visit(ctx["bamba"], param)
       }
 
       bamba(ctx: any, param: any) {
-        expect(keys(ctx)).to.deep.equal(["C"])
+        expect(Object.keys(ctx)).to.deep.equal(["C"])
         return 666 + param
       }
     }

--- a/packages/chevrotain/test/parse/grammar/checks_spec.ts
+++ b/packages/chevrotain/test/parse/grammar/checks_spec.ts
@@ -17,8 +17,6 @@ import {
   validateTooManyAlts
 } from "../../../src/parse/grammar/checks"
 import { createToken } from "../../../src/scan/tokens_public"
-import first from "lodash/first"
-import map from "lodash/map"
 import {
   Alternation,
   Alternative,
@@ -33,7 +31,6 @@ import { defaultGrammarValidatorErrorProvider } from "../../../src/parse/errors_
 import { IToken, TokenType } from "@chevrotain/types"
 import { expect } from "chai"
 import { createDeferredTokenBuilder } from "../../utils/builders"
-import omit from "lodash/omit"
 
 const getIdentTok = createDeferredTokenBuilder({
   name: "IdentTok",
@@ -137,7 +134,7 @@ describe("the grammar validations", () => {
       defaultGrammarValidatorErrorProvider,
       "bamba"
     )
-    expect(actualErrors.map((e) => omit(e, "message"))).to.deep.equal(
+    expect(actualErrors.map(({ message, ...e }) => e)).to.deep.equal(
       expectedErrorsNoMsg
     )
   })
@@ -363,7 +360,7 @@ describe("the getFirstNoneTerminal function", () => {
       })
     ])
     expect(result).to.have.length(1)
-    expect(first(result)!.name).to.equal("dummyRule")
+    expect(result[0].name).to.equal("dummyRule")
   })
 
   it("can find the firstNoneTerminal of a sequence with two items", () => {
@@ -379,7 +376,7 @@ describe("the getFirstNoneTerminal function", () => {
     ]
     const result = getFirstNoneTerminal(sqeuence)
     expect(result).to.have.length(1)
-    expect(first(result)!.name).to.equal("dummyRule")
+    expect(result[0].name).to.equal("dummyRule")
   })
 
   it("can find the firstNoneTerminal of a sequence with two items where the first is optional", () => {
@@ -399,7 +396,7 @@ describe("the getFirstNoneTerminal function", () => {
     ]
     const result = getFirstNoneTerminal(sqeuence)
     expect(result).to.have.length(2)
-    const resultRuleNames = map(result, (currItem) => currItem.name)
+    const resultRuleNames = result.map((currItem) => currItem.name)
     expect(resultRuleNames).to.include.members(["dummyRule", "dummyRule2"])
   })
 
@@ -436,7 +433,7 @@ describe("the getFirstNoneTerminal function", () => {
     ]
     const result = getFirstNoneTerminal(alternation)
     expect(result).to.have.length(3)
-    const resultRuleNames = map(result, (currItem) => currItem.name)
+    const resultRuleNames = result.map((currItem) => currItem.name)
     expect(resultRuleNames).to.include.members([
       "dummyRule",
       "dummyRule2",
@@ -473,7 +470,7 @@ describe("the getFirstNoneTerminal function", () => {
     ]
     const result = getFirstNoneTerminal(alternation)
     expect(result).to.have.length(2)
-    const resultRuleNames = map(result, (currItem) => currItem.name)
+    const resultRuleNames = result.map((currItem) => currItem.name)
     expect(resultRuleNames).to.include.members(["dummyRule", "dummyRule3"])
   })
 
@@ -506,7 +503,7 @@ describe("the getFirstNoneTerminal function", () => {
     ]
     const result = getFirstNoneTerminal(alternation)
     expect(result).to.have.length(1)
-    const resultRuleNames = map(result, (currItem) => currItem.name)
+    const resultRuleNames = result.map((currItem) => currItem.name)
     expect(resultRuleNames).to.include.members(["dummyRule"])
   })
 

--- a/packages/chevrotain/test/parse/grammar/follow_spec.ts
+++ b/packages/chevrotain/test/parse/grammar/follow_spec.ts
@@ -12,7 +12,6 @@ import {
   Rule,
   Terminal
 } from "@chevrotain/gast"
-import keys from "lodash/keys"
 import { expect } from "chai"
 import { createToken } from "../../../src/scan/tokens_public"
 import { TokenType } from "@chevrotain/types"
@@ -137,7 +136,7 @@ describe("The Grammar Ast Follows model", () => {
 
   it("can compute the follows for Top level production ref in ActionDec", () => {
     const actual = new ResyncFollowsWalker(actionDec).startWalking()
-    const actualFollowNames = keys(actual)
+    const actualFollowNames = Object.keys(actual)
     expect(actualFollowNames.length).to.equal(3)
     expect(actual["paramSpec1_~IN~_actionDec"].length).to.equal(2)
     setEquality(actual["paramSpec1_~IN~_actionDec"], [CommaTok, RParenTok])
@@ -149,6 +148,6 @@ describe("The Grammar Ast Follows model", () => {
 
   it("can compute all follows for a set of top level productions", () => {
     const actual = computeAllProdsFollows([actionDec])
-    expect(keys(actual).length).to.equal(3)
+    expect(Object.keys(actual).length).to.equal(3)
   })
 })

--- a/packages/chevrotain/test/parse/grammar/interperter_spec.ts
+++ b/packages/chevrotain/test/parse/grammar/interperter_spec.ts
@@ -1,5 +1,4 @@
 import { expect } from "chai"
-import map from "lodash/map"
 import { IToken, ITokenGrammarPath, TokenType } from "@chevrotain/types"
 import {
   NextAfterTokenWalker,
@@ -798,7 +797,7 @@ describe("The Grammar Interpeter namespace", () => {
 
   describe("The chevrotain grammar interpreter capabilities", () => {
     function extractPartialPaths(newResultFormat: PartialPathAndSuffixes[]) {
-      return map(newResultFormat, (currItem) => currItem.partialPath)
+      return newResultFormat.map((currItem) => currItem.partialPath)
     }
 
     class Alpha {
@@ -1076,11 +1075,11 @@ describe("The Grammar Interpeter namespace", () => {
 
     context("can calculate the next possible single tokens for: ", () => {
       function INPUT(tokTypes: TokenType[]): IToken[] {
-        return map(tokTypes, (currTokType) => createRegularToken(currTokType))
+        return tokTypes.map((currTokType) => createRegularToken(currTokType))
       }
 
       function pluckTokenTypes(arr: any[]): TokenType[] {
-        return map(arr, (currItem) => currItem.nextTokenType)
+        return arr.map((currItem) => currItem.nextTokenType)
       }
 
       it("Sequence positive", () => {

--- a/packages/chevrotain/test/parse/grammar/lookahead_spec.ts
+++ b/packages/chevrotain/test/parse/grammar/lookahead_spec.ts
@@ -9,7 +9,6 @@ import {
   lookAheadSequenceFromAlternatives,
   PROD_TYPE
 } from "../../../src/parse/grammar/lookahead"
-import map from "lodash/map"
 import {
   augmentTokenTypes,
   tokenStructuredMatcher
@@ -734,7 +733,7 @@ context("lookahead specs", () => {
         public input: IToken[]
 
         constructor(public inputConstructors: TokenType[]) {
-          this.input = map(inputConstructors, (currConst) =>
+          this.input = inputConstructors.map((currConst) =>
             createRegularToken(currConst)
           )
         }

--- a/packages/chevrotain/test/scan/lexer_spec.ts
+++ b/packages/chevrotain/test/scan/lexer_spec.ts
@@ -1,9 +1,3 @@
-import last from "lodash/last"
-import map from "lodash/map"
-import forEach from "lodash/forEach"
-import isString from "lodash/isString"
-import isRegExp from "lodash/isRegExp"
-import keys from "lodash/keys"
 import { createToken } from "../../src/scan/tokens_public"
 import { Lexer, LexerDefinitionErrorType } from "../../src/scan/lexer_public"
 import {
@@ -663,14 +657,15 @@ function defineLexerSpecs(
             useSticky: false
           })
 
-          const allPatterns = map(
-            analyzeResult.patternIdxToConfig,
+          const allPatterns = analyzeResult.patternIdxToConfig.map(
             (currConfig) => currConfig.pattern
           )
 
           expect(allPatterns.length).to.equal(8)
-          const allPatternsString = map(allPatterns, (pattern) => {
-            return isString(pattern) ? pattern : (pattern as RegExp).source
+          const allPatternsString = allPatterns.map((pattern) => {
+            return typeof pattern === "string"
+              ? pattern
+              : (pattern as RegExp).source
           })
           setEquality(allPatternsString, [
             "^(?:(\\t| ))",
@@ -683,11 +678,10 @@ function defineLexerSpecs(
             "^(?:return)"
           ])
 
-          const patternIdxToClass = map(
-            analyzeResult.patternIdxToConfig,
+          const patternIdxToClass = analyzeResult.patternIdxToConfig.map(
             (currConfig) => currConfig.tokenType
           )
-          expect(keys(patternIdxToClass).length).to.equal(8)
+          expect(Object.keys(patternIdxToClass).length).to.equal(8)
           expect(patternIdxToClass[0]).to.equal(If)
           expect(patternIdxToClass[1]).to.equal(Else)
           expect(patternIdxToClass[2]).to.equal(Return)
@@ -717,13 +711,14 @@ function defineLexerSpecs(
           const analyzeResult = analyzeTokenTypes(tokenClasses, {
             useSticky: true
           })
-          const allPatterns = map(
-            analyzeResult.patternIdxToConfig,
+          const allPatterns = analyzeResult.patternIdxToConfig.map(
             (currConfig) => currConfig.pattern
           )
           expect(allPatterns.length).to.equal(8)
-          const allPatternsString = map(allPatterns, (pattern) => {
-            return isString(pattern) ? pattern : (pattern as RegExp).source
+          const allPatternsString = allPatterns.map((pattern) => {
+            return typeof pattern === "string"
+              ? pattern
+              : (pattern as RegExp).source
           })
           setEquality(allPatternsString, [
             "(\\t| )",
@@ -736,16 +731,15 @@ function defineLexerSpecs(
             "return"
           ])
 
-          forEach(allPatterns, (currPattern) => {
-            if (isRegExp(currPattern)) {
+          allPatterns.forEach((currPattern) => {
+            if (currPattern instanceof RegExp) {
               expect(currPattern.sticky).to.be.true
             }
           })
-          const patternIdxToClass = map(
-            analyzeResult.patternIdxToConfig,
+          const patternIdxToClass = analyzeResult.patternIdxToConfig.map(
             (currConfig) => currConfig.tokenType
           )
-          expect(keys(patternIdxToClass).length).to.equal(8)
+          expect(Object.keys(patternIdxToClass).length).to.equal(8)
           expect(patternIdxToClass[0]).to.equal(If)
           expect(patternIdxToClass[1]).to.equal(Else)
           expect(patternIdxToClass[2]).to.equal(Return)
@@ -768,14 +762,14 @@ function defineLexerSpecs(
             pattern: /\d+/
           })
         ])
-        const lastToken = last(ltCounter.tokenize("1\r\n1\r1").tokens)!
+        const lastToken = ltCounter.tokenize("1\r\n1\r1").tokens.pop()!
         expect(lastToken.startLine).to.equal(3)
 
-        const lastToken2 = last(ltCounter.tokenize("\r\r\r1234\r\n1").tokens)!
+        const lastToken2 = ltCounter.tokenize("\r\r\r1234\r\n1").tokens.pop()!
         expect(lastToken2.startLine).to.equal(5)
         expect(lastToken2.startColumn).to.equal(1)
 
-        const lastToken3 = last(ltCounter.tokenize("2\r3\n\r4\n5").tokens)!
+        const lastToken3 = ltCounter.tokenize("2\r3\n\r4\n5").tokens.pop()!
         expect(lastToken3.startLine).to.equal(5)
       })
 
@@ -791,14 +785,14 @@ function defineLexerSpecs(
             pattern: /\d+(?=|\n)/
           })
         ])
-        const lastToken = last(ltCounter.tokenize("1\r\n1\r1").tokens)!
+        const lastToken = ltCounter.tokenize("1\r\n1\r1").tokens.pop()!
         expect(lastToken.startLine).to.equal(3)
 
-        const lastToken2 = last(ltCounter.tokenize("\r\r\r1234\r\n1").tokens)!
+        const lastToken2 = ltCounter.tokenize("\r\r\r1234\r\n1").tokens.pop()!
         expect(lastToken2.startLine).to.equal(5)
         expect(lastToken2.startColumn).to.equal(1)
 
-        const lastToken3 = last(ltCounter.tokenize("2\r3\n\r4\n5").tokens)!
+        const lastToken3 = ltCounter.tokenize("2\r3\n\r4\n5").tokens.pop()!
         expect(lastToken3.startLine).to.equal(5)
       })
 
@@ -815,14 +809,14 @@ function defineLexerSpecs(
             pattern: /\d+(?!a\n)/
           })
         ])
-        const lastToken = last(ltCounter.tokenize("1\r\n1\r1").tokens)!
+        const lastToken = ltCounter.tokenize("1\r\n1\r1").tokens.pop()!
         expect(lastToken.startLine).to.equal(3)
 
-        const lastToken2 = last(ltCounter.tokenize("\r\r\r1234\r\n1").tokens)!
+        const lastToken2 = ltCounter.tokenize("\r\r\r1234\r\n1").tokens.pop()!
         expect(lastToken2.startLine).to.equal(5)
         expect(lastToken2.startColumn).to.equal(1)
 
-        const lastToken3 = last(ltCounter.tokenize("2\r3\n\r4\n5").tokens)!
+        const lastToken3 = ltCounter.tokenize("2\r3\n\r4\n5").tokens.pop()!
         expect(lastToken3.startLine).to.equal(5)
       })
 
@@ -838,7 +832,7 @@ function defineLexerSpecs(
             pattern: /\d+/
           })
         ])
-        const lastToken = last(ltCounter.tokenize("1\n1\n1").tokens)!
+        const lastToken = ltCounter.tokenize("1\n1\n1").tokens.pop()!
         expect(lastToken.startLine).to.equal(3)
       })
 
@@ -853,7 +847,7 @@ function defineLexerSpecs(
             pattern: /\d+/
           })
         ])
-        const lastToken = last(ltCounter.tokenize("1\n1\n1").tokens)!
+        const lastToken = ltCounter.tokenize("1\n1\n1").tokens.pop()!
         expect(lastToken.startLine).to.equal(3)
       })
 
@@ -1112,7 +1106,7 @@ function defineLexerSpecs(
               pattern: /\d+/
             })
           ])
-          const lastToken = last(ltCounter.tokenize("1\n1\n1").tokens)!
+          const lastToken = ltCounter.tokenize("1\n1\n1").tokens.pop()!
           expect(lastToken.startLine).to.equal(3)
         })
 
@@ -1714,7 +1708,7 @@ function defineLexerSpecs(
           const lexResult = ModeLexer.tokenize(input)
           expect(lexResult.errors).to.be.empty
 
-          const images = map(lexResult.tokens, (currTok) => currTok.image)
+          const images = lexResult.tokens.map((currTok) => currTok.image)
           expect(images).to.deep.equal([
             "1",
             "LETTERS",
@@ -1744,7 +1738,7 @@ function defineLexerSpecs(
           const lexResult = ModeLexer.tokenize(input, "letters")
           expect(lexResult.errors).to.be.empty
 
-          const images = map(lexResult.tokens, (currTok) => currTok.image)
+          const images = lexResult.tokens.map((currTok) => currTok.image)
           expect(images).to.deep.equal(["A", "G", "SIGNS", "^"])
         })
 
@@ -1755,7 +1749,7 @@ function defineLexerSpecs(
           expect(lexResult.errors[0].message).to.include("skipped 1")
           expect(lexResult.errors[0].message).to.include(">1<")
 
-          const images = map(lexResult.tokens, (currTok) => currTok.image)
+          const images = lexResult.tokens.map((currTok) => currTok.image)
 
           expect(images).to.deep.equal([
             "1",
@@ -1780,7 +1774,7 @@ function defineLexerSpecs(
 
           expect(lexResult.errors[0].length).to.equal(12)
 
-          const images = map(lexResult.tokens, (currTok) => currTok.image)
+          const images = lexResult.tokens.map((currTok) => currTok.image)
           expect(images).to.deep.equal(["1", "EXIT_NUMBERS", "2"])
         })
 
@@ -1789,7 +1783,7 @@ function defineLexerSpecs(
           const lexResult = ModeLexer.tokenize(input)
           expect(lexResult.errors).to.be.empty
 
-          const images = map(lexResult.tokens, (currTok) => currTok.image)
+          const images = lexResult.tokens.map((currTok) => currTok.image)
           expect(images).to.deep.equal([
             "LETTERS",
             "SIGNS_AND_EXIT_LETTERS",
@@ -2218,7 +2212,7 @@ function wrapWithCustom(baseExtendToken: (c: ITokenConfig) => TokenType) {
 
     const pattern = newToken.PATTERN
     if (
-      isRegExp(pattern) &&
+      pattern instanceof RegExp &&
       !/\\n|\\r|\\s/g.test(pattern.source) &&
       pattern !== Lexer.NA
     ) {

--- a/packages/chevrotain/test/scan/skip_validations_spec.ts
+++ b/packages/chevrotain/test/scan/skip_validations_spec.ts
@@ -1,6 +1,4 @@
 import { Lexer } from "../../src/scan/lexer_public"
-import flatten from "lodash/flatten"
-import find from "lodash/find"
 import { expect } from "chai"
 import { SinonSpy } from "sinon/index"
 
@@ -21,17 +19,17 @@ describe("Chevrotain's Lexer Init Performance Tracing", () => {
     new Lexer([], { traceInitPerf: true })
 
     expect(consoleLogSpy).to.have.been.called
-    const consoleArgs = flatten(consoleLogSpy.args)
+    const consoleArgs = ([] as string[]).concat(...consoleLogSpy.args)
 
-    const runtimeChecksArg = find(consoleArgs, (item: string) =>
+    const runtimeChecksArg = consoleArgs.find((item: string) =>
       /performRuntimeChecks/.test(item)
     )
     expect(runtimeChecksArg).to.not.be.undefined
-    const warningRuntimeChecksAra = find(consoleArgs, (item: string) =>
+    const warningRuntimeChecksAra = consoleArgs.find((item: string) =>
       /performWarningRuntimeChecks/.test(item)
     )
     expect(warningRuntimeChecksAra).to.not.be.undefined
-    const validateArg = find(consoleArgs, (item: string) =>
+    const validateArg = consoleArgs.find((item: string) =>
       /validatePatterns/.test(item)
     )
     expect(validateArg).to.not.be.undefined
@@ -41,17 +39,17 @@ describe("Chevrotain's Lexer Init Performance Tracing", () => {
     new Lexer([], { traceInitPerf: true, skipValidations: true })
 
     expect(consoleLogSpy).to.have.been.called
-    const consoleArgs = flatten(consoleLogSpy.args)
+    const consoleArgs = ([] as string[]).concat(...consoleLogSpy.args)
 
-    const runtimeChecksArg = find(consoleArgs, (item: string) =>
+    const runtimeChecksArg = consoleArgs.find((item: string) =>
       /performRuntimeChecks/.test(item)
     )
     expect(runtimeChecksArg).to.be.undefined
-    const warningRuntimeChecksAra = find(consoleArgs, (item: string) =>
+    const warningRuntimeChecksAra = consoleArgs.find((item: string) =>
       /performWarningRuntimeChecks/.test(item)
     )
     expect(warningRuntimeChecksAra).to.be.undefined
-    const validateArg = find(consoleArgs, (item: string) =>
+    const validateArg = consoleArgs.find((item: string) =>
       /validatePatterns/.test(item)
     )
     expect(validateArg).to.be.undefined

--- a/packages/cst-dts-gen-test/package.json
+++ b/packages/cst-dts-gen-test/package.json
@@ -25,8 +25,7 @@
     "@chevrotain/cst-dts-gen": "10.4.2",
     "@chevrotain/gast": "10.4.2",
     "@chevrotain/types": "10.4.2",
-    "chevrotain": "10.4.2",
-    "lodash": "4.17.21"
+    "chevrotain": "10.4.2"
   },
   "devDependencies": {
     "glob": "8.0.3"

--- a/packages/cst-dts-gen/package.json
+++ b/packages/cst-dts-gen/package.json
@@ -32,10 +32,8 @@
   "dependencies": {
     "@chevrotain/gast": "10.4.2",
     "@chevrotain/types": "10.4.2",
-    "lodash": "4.17.21"
   },
   "devDependencies": {
-    "@types/lodash": "4.14.191"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/cst-dts-gen/src/generate.ts
+++ b/packages/cst-dts-gen/src/generate.ts
@@ -1,9 +1,3 @@
-import flatten from "lodash/flatten"
-import isArray from "lodash/isArray"
-import map from "lodash/map"
-import reduce from "lodash/reduce"
-import uniq from "lodash/uniq"
-import upperFirst from "lodash/upperFirst"
 import { GenerateDtsOptions } from "@chevrotain/types"
 import {
   CstNodeTypeDefinition,
@@ -24,7 +18,7 @@ export function genDts(
   )
 
   contentParts = contentParts.concat(
-    flatten(map(model, (node) => genCstNodeTypes(node)))
+    ...model.map((node) => genCstNodeTypes(node))
   )
 
   if (options.includeVisitorInterface) {
@@ -57,7 +51,7 @@ function genNodeChildrenType(node: CstNodeTypeDefinition) {
   const typeName = getNodeChildrenTypeName(node.name)
 
   return `export type ${typeName} = {
-  ${map(node.properties, (property) => genChildProperty(property)).join("\n  ")}
+  ${node.properties.map((property) => genChildProperty(property)).join("\n  ")}
 };`
 }
 
@@ -68,7 +62,7 @@ function genChildProperty(prop: PropertyTypeDefinition) {
 
 function genVisitor(name: string, nodes: CstNodeTypeDefinition[]) {
   return `export interface ${name}<IN, OUT> extends ICstVisitor<IN, OUT> {
-  ${map(nodes, (node) => genVisitorFunction(node)).join("\n  ")}
+  ${nodes.map((node) => genVisitorFunction(node)).join("\n  ")}
 }`
 }
 
@@ -78,9 +72,9 @@ function genVisitorFunction(node: CstNodeTypeDefinition) {
 }
 
 function buildTypeString(type: PropertyArrayType) {
-  if (isArray(type)) {
-    const typeNames = uniq(map(type, (t) => getTypeString(t)))
-    const typeString = reduce(typeNames, (sum, t) => sum + " | " + t)
+  if (Array.isArray(type)) {
+    const typeNames = Array.from(new Set(type.map((t) => getTypeString(t))))
+    const typeString = typeNames.reduce((sum, t) => sum + " | " + t)
     return "(" + typeString + ")"
   } else {
     return getTypeString(type)
@@ -95,9 +89,9 @@ function getTypeString(type: TokenArrayType | RuleArrayType) {
 }
 
 function getNodeInterfaceName(ruleName: string) {
-  return upperFirst(ruleName) + "CstNode"
+  return `${ruleName[0].toUpperCase()}${ruleName.slice(1)}CstNode`
 }
 
 function getNodeChildrenTypeName(ruleName: string) {
-  return upperFirst(ruleName) + "CstChildren"
+  return `${ruleName[0].toUpperCase()}${ruleName.slice(1)}CstChildren`
 }

--- a/packages/gast/package.json
+++ b/packages/gast/package.json
@@ -34,11 +34,9 @@
     "coverage": "nyc mocha"
   },
   "dependencies": {
-    "@chevrotain/types": "10.4.2",
-    "lodash": "4.17.21"
+    "@chevrotain/types": "10.4.2"
   },
   "devDependencies": {
-    "@types/lodash": "4.14.191"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/gast/src/helpers.ts
+++ b/packages/gast/src/helpers.ts
@@ -1,7 +1,3 @@
-import some from "lodash/some"
-import every from "lodash/every"
-import has from "lodash/has"
-import includes from "lodash/includes"
 import {
   AbstractProduction,
   Alternation,
@@ -50,18 +46,20 @@ export function isOptionalProd(
   // may be indirectly optional ((A?B?C?) | (D?E?F?))
   if (prod instanceof Alternation) {
     // for OR its enough for just one of the alternatives to be optional
-    return some((<Alternation>prod).definition, (subProd: IProduction) => {
+    return (<Alternation>prod).definition.some((subProd: IProduction) => {
       return isOptionalProd(subProd, alreadyVisited)
     })
-  } else if (prod instanceof NonTerminal && includes(alreadyVisited, prod)) {
+  } else if (
+    prod instanceof NonTerminal &&
+    alreadyVisited.indexOf(prod) !== -1
+  ) {
     // avoiding stack overflow due to infinite recursion
     return false
   } else if (prod instanceof AbstractProduction) {
     if (prod instanceof NonTerminal) {
       alreadyVisited.push(prod)
     }
-    return every(
-      (<AbstractProduction>prod).definition,
+    return (<AbstractProduction>prod).definition.every(
       (subProd: IProduction) => {
         return isOptionalProd(subProd, alreadyVisited)
       }

--- a/packages/gast/src/model.ts
+++ b/packages/gast/src/model.ts
@@ -1,9 +1,3 @@
-import map from "lodash/map"
-import forEach from "lodash/forEach"
-import isString from "lodash/isString"
-import isRegExp from "lodash/isRegExp"
-import pickBy from "lodash/pickBy"
-import assign from "lodash/assign"
 import {
   IGASTVisitor,
   IProduction,
@@ -25,7 +19,7 @@ function tokenLabel(tokType: TokenType): string {
 function hasTokenLabel(
   obj: TokenType
 ): obj is TokenType & Pick<Required<TokenType>, "LABEL"> {
-  return isString(obj.LABEL) && obj.LABEL !== ""
+  return typeof obj.LABEL === "string" && obj.LABEL !== ""
 }
 
 export abstract class AbstractProduction<T extends IProduction = IProduction>
@@ -42,7 +36,7 @@ export abstract class AbstractProduction<T extends IProduction = IProduction>
 
   accept(visitor: IGASTVisitor): void {
     visitor.visit(this)
-    forEach(this.definition, (prod) => {
+    this.definition.forEach((prod) => {
       prod.accept(visitor)
     })
   }
@@ -64,10 +58,7 @@ export class NonTerminal
     idx?: number
   }) {
     super([])
-    assign(
-      this,
-      pickBy(options, (v) => v !== undefined)
-    )
+    Object.assign(this, options)
   }
 
   set definition(definition: IProduction[]) {
@@ -97,10 +88,7 @@ export class Rule extends AbstractProduction {
     orgText?: string
   }) {
     super(options.definition)
-    assign(
-      this,
-      pickBy(options, (v) => v !== undefined)
-    )
+    Object.assign(this, options)
   }
 }
 
@@ -112,10 +100,7 @@ export class Alternative extends AbstractProduction {
     ignoreAmbiguities?: boolean
   }) {
     super(options.definition)
-    assign(
-      this,
-      pickBy(options, (v) => v !== undefined)
-    )
+    Object.assign(this, options)
   }
 }
 
@@ -132,10 +117,7 @@ export class Option
     maxLookahead?: number
   }) {
     super(options.definition)
-    assign(
-      this,
-      pickBy(options, (v) => v !== undefined)
-    )
+    Object.assign(this, options)
   }
 }
 
@@ -152,10 +134,7 @@ export class RepetitionMandatory
     maxLookahead?: number
   }) {
     super(options.definition)
-    assign(
-      this,
-      pickBy(options, (v) => v !== undefined)
-    )
+    Object.assign(this, options)
   }
 }
 
@@ -173,10 +152,7 @@ export class RepetitionMandatoryWithSeparator
     idx?: number
   }) {
     super(options.definition)
-    assign(
-      this,
-      pickBy(options, (v) => v !== undefined)
-    )
+    Object.assign(this, options)
   }
 }
 
@@ -194,10 +170,7 @@ export class Repetition
     maxLookahead?: number
   }) {
     super(options.definition)
-    assign(
-      this,
-      pickBy(options, (v) => v !== undefined)
-    )
+    Object.assign(this, options)
   }
 }
 
@@ -215,10 +188,7 @@ export class RepetitionWithSeparator
     idx?: number
   }) {
     super(options.definition)
-    assign(
-      this,
-      pickBy(options, (v) => v !== undefined)
-    )
+    Object.assign(this, options)
   }
 }
 
@@ -246,10 +216,7 @@ export class Alternation
     maxLookahead?: number
   }) {
     super(options.definition)
-    assign(
-      this,
-      pickBy(options, (v) => v !== undefined)
-    )
+    Object.assign(this, options)
   }
 }
 
@@ -263,10 +230,7 @@ export class Terminal implements IProductionWithOccurrence {
     label?: string
     idx?: number
   }) {
-    assign(
-      this,
-      pickBy(options, (v) => v !== undefined)
-    )
+    Object.assign(this, options)
   }
 
   accept(visitor: IGASTVisitor): void {
@@ -320,12 +284,12 @@ export type ISerializedGastAny =
   | ISerializedTerminalWithSeparator
 
 export function serializeGrammar(topRules: Rule[]): ISerializedGast[] {
-  return map(topRules, serializeProduction)
+  return topRules.map(serializeProduction)
 }
 
 export function serializeProduction(node: IProduction): ISerializedGast {
   function convertDefinition(definition: IProduction[]): ISerializedGast[] {
-    return map(definition, serializeProduction)
+    return definition.map(serializeProduction)
   }
   /* istanbul ignore else */
   if (node instanceof NonTerminal) {
@@ -335,7 +299,7 @@ export function serializeProduction(node: IProduction): ISerializedGast {
       idx: node.idx
     }
 
-    if (isString(node.label)) {
+    if (typeof node.label === "string") {
       serializedNonTerminal.label = node.label
     }
 
@@ -395,15 +359,14 @@ export function serializeProduction(node: IProduction): ISerializedGast {
       idx: node.idx
     }
 
-    if (isString(node.label)) {
+    if (typeof node.label === "string") {
       serializedTerminal.terminalLabel = node.label
     }
 
     const pattern = node.terminalType.PATTERN
     if (node.terminalType.PATTERN) {
-      serializedTerminal.pattern = isRegExp(pattern)
-        ? (<any>pattern).source
-        : pattern
+      serializedTerminal.pattern =
+        pattern instanceof RegExp ? (<any>pattern).source : pattern
     }
 
     return serializedTerminal

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,9 +164,6 @@ importers:
       '@chevrotain/types':
         specifier: 10.5.0
         version: link:../types
-      lodash:
-        specifier: 4.17.21
-        version: 4.17.21
       regexp-to-ast:
         specifier: 0.5.0
         version: 0.5.0
@@ -6520,6 +6517,7 @@ packages:
 
   /lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+    dev: true
 
   /log-symbols@4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,15 +120,12 @@ importers:
       '@chevrotain/cst-dts-gen': 10.4.2
       '@chevrotain/gast': 10.4.2
       '@chevrotain/types': 10.4.2
-      '@chevrotain/utils': 10.4.2
-      '@types/lodash': 4.14.191
       error-stack-parser: 2.1.4
       esbuild: 0.16.10
       gen-esm-wrapper: 1.1.3
       gitty: 3.7.2
       jsdom: 20.0.3
       jsonfile: 6.1.0
-      lodash: 4.17.21
       regexp-to-ast: 0.5.0
       require-from-string: 2.0.2
       sinon: 15.0.1
@@ -140,10 +137,8 @@ importers:
       '@chevrotain/gast': link:../gast
       '@chevrotain/types': link:../types
       '@chevrotain/utils': link:../utils
-      lodash: 4.17.21
       regexp-to-ast: 0.5.0
     devDependencies:
-      '@types/lodash': 4.14.191
       error-stack-parser: 2.1.4
       esbuild: 0.16.10
       gen-esm-wrapper: 1.1.3
@@ -160,14 +155,9 @@ importers:
     specifiers:
       '@chevrotain/gast': 10.4.2
       '@chevrotain/types': 10.4.2
-      '@types/lodash': 4.14.191
-      lodash: 4.17.21
     dependencies:
       '@chevrotain/gast': link:../gast
       '@chevrotain/types': link:../types
-      lodash: 4.17.21
-    devDependencies:
-      '@types/lodash': 4.14.191
 
   packages/cst-dts-gen-test:
     specifiers:
@@ -176,26 +166,19 @@ importers:
       '@chevrotain/types': 10.4.2
       chevrotain: 10.4.2
       glob: 8.0.3
-      lodash: 4.17.21
     dependencies:
       '@chevrotain/cst-dts-gen': link:../cst-dts-gen
       '@chevrotain/gast': link:../gast
       '@chevrotain/types': link:../types
       chevrotain: link:../chevrotain
-      lodash: 4.17.21
     devDependencies:
       glob: 8.0.3
 
   packages/gast:
     specifiers:
       '@chevrotain/types': 10.4.2
-      '@types/lodash': 4.14.191
-      lodash: 4.17.21
     dependencies:
       '@chevrotain/types': link:../types
-      lodash: 4.17.21
-    devDependencies:
-      '@types/lodash': 4.14.191
 
   packages/types:
     specifiers:
@@ -2373,10 +2356,6 @@ packages:
     resolution: {integrity: sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==}
     dev: true
 
-  /@types/lodash/4.14.191:
-    resolution: {integrity: sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==}
-    dev: true
-
   /@types/markdown-it-emoji/2.0.2:
     resolution: {integrity: sha512-2ln8Wjbcj/0oRi/6VnuMeWEHHuK8uapFttvcLmDIe1GKCsFBLOLBX+D+xhDa9oWOQV0IpvxwrSfKKssAqqroog==}
     dependencies:
@@ -4017,8 +3996,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
-      JSONStream: 1.3.5
       is-text-path: 1.0.1
+      JSONStream: 1.3.5
       lodash: 4.17.21
       meow: 8.1.2
       split2: 3.2.2
@@ -6548,6 +6527,7 @@ packages:
 
   /lodash/4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+    dev: true
 
   /log-symbols/4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,6 +164,9 @@ importers:
       '@chevrotain/types':
         specifier: 10.5.0
         version: link:../types
+      '@chevrotain/utils':
+        specifier: 10.5.0
+        version: link:../utils
       regexp-to-ast:
         specifier: 0.5.0
         version: 0.5.0


### PR DESCRIPTION
@joliss did extensive work to remove the lodash dependency. 

- https://github.com/Chevrotain/chevrotain/pull/1871

We are trying to replace Jison with a Chevrotain based parser (langium) at MermaidJS.
As our primary use case is browser based, package size is a major issue for us. 
`lodash` is also causing many build time warnings when built with vite. 

Size comparison

| File               | master | remove_lodash | ~reduction | reduction kb |
| ------------------ | ------ | ------------- | ---------- | ------------ |
| chevrotain.js      | 627757 | 410573        | 34%        | 217          |
| chevrotain.min.js  | 203501 | 162222        | 20%        | 41           |
| chevrotain.mjs     | 517576 | 351780        | 32%        | 166          |
| chevrotain.min.mjs | 209131 | 164468        | 21%        | 45           |

