### PR TITLE
fix: add missing exports field

### DIFF
--- a/packages/cst-dts-gen/package.json
+++ b/packages/cst-dts-gen/package.json
@@ -6,6 +6,9 @@
   "bugs": {
     "url": "https://github.com/Chevrotain/chevrotain/issues"
   },
+  "exports": {
+    ".": "./lib/src/api.js"
+  },
   "license": "Apache-2.0",
   "typings": "lib/src/api.d.ts",
   "main": "lib/src/api.js",

--- a/packages/gast/package.json
+++ b/packages/gast/package.json
@@ -6,6 +6,9 @@
   "bugs": {
     "url": "https://github.com/Chevrotain/chevrotain/issues"
   },
+  "exports": {
+    ".": "./lib/src/api.js"
+  },
   "license": "Apache-2.0",
   "typings": "lib/src/api.d.ts",
   "main": "lib/src/api.js",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -10,6 +10,9 @@
   "author": {
     "name": "Shahar Soel"
   },
+  "exports": {
+    ".": "./lib/src/api.js"
+  },
   "typings": "lib/src/api.d.ts",
   "main": "lib/src/api.js",
   "files": [


### PR DESCRIPTION
Modern bundler settings require the exports field to be present. See https://github.com/Chevrotain/chevrotain/issues/1941