### PR TITLE
docs: fix punctuation in step1_lexing.md

### DIFF
--- a/packages/website/docs/tutorial/step1_lexing.md
+++ b/packages/website/docs/tutorial/step1_lexing.md
@@ -57,7 +57,7 @@ const WhiteSpace = createToken({
 
 ## All Our Tokens
 
-Lets examine all the needed Tokens definitions"
+Lets examine all the needed Tokens definitions:
 
 ```javascript
 const Identifier = createToken({ name: "Identifier", pattern: /[a-zA-Z]\w*/ })


### PR DESCRIPTION
Someone must've hit `"` by accident, which is right next to `:` on the ANSI keyboard layout.