### PR TITLE
build!: change compile target to ES2015

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,7 +1,7 @@
 {
   "compileOnSave": true,
   "compilerOptions": {
-    "target": "ES5",
+    "target": "ES2015",
     "composite": true,
     "module": "CommonJS",
     "esModuleInterop": true,


### PR DESCRIPTION
- Reduces `chevrotain.min.js` by ~30Kb (#1697)
- Was already introduced in 10.x version but reverted in 10.3.0 due to unexpected breaking changes.
  - see: https://github.com/Chevrotain/chevrotain/issues/1845#issuecomment-1221411613 