### PR TITLE
fix: add `types` to exports

### DIFF
--- a/packages/chevrotain/package.json
+++ b/packages/chevrotain/package.json
@@ -26,7 +26,8 @@
   "types": "./chevrotain.d.ts",
   "exports": {
     ".": {
-      "import": "./lib/src/api.js"
+      "import": "./lib/src/api.js",
+      "types": "./chevrotain.d.ts"
     }
   },
   "files": [

--- a/packages/cst-dts-gen/package.json
+++ b/packages/cst-dts-gen/package.json
@@ -11,7 +11,8 @@
   "types": "./lib/src/api.d.ts",
   "exports": {
     ".": {
-      "import": "./lib/src/api.js"
+      "import": "./lib/src/api.js",
+      "types": "./lib/src/api.d.ts"
     }
   },
   "files": [

--- a/packages/gast/package.json
+++ b/packages/gast/package.json
@@ -8,10 +8,11 @@
   },
   "license": "Apache-2.0",
   "type": "module",
-  "types": "lib/src/api.d.ts",
+  "types": "./lib/src/api.d.ts",
   "exports": {
     ".": {
-      "import": "./lib/src/api.js"
+      "import": "./lib/src/api.js",
+      "types": "./lib/src/api.d.ts"
     }
   },
   "files": [

--- a/packages/regexp-to-ast/package.json
+++ b/packages/regexp-to-ast/package.json
@@ -15,7 +15,8 @@
   "types": "./types.d.ts",
   "exports": {
     ".": {
-      "import": "./lib/src/api.js"
+      "import": "./lib/src/api.js",
+      "types": "./types.d.ts"
     }
   },
   "## COMMENT": "Not exposing the generated *.d.ts as it seems to conflict with types.d.ts when `moduleResolution=nodenext`in tsconfig...",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -11,10 +11,11 @@
     "name": "Shahar Soel"
   },
   "type": "module",
-  "typings": "lib/src/api.d.ts",
+  "types": "./lib/src/api.d.ts",
   "exports": {
     ".": {
-      "import": "./lib/src/api.js"
+      "import": "./lib/src/api.js",
+      "types": "./lib/src/api.d.ts"
     }
   },
   "files": [


### PR DESCRIPTION
Closes https://github.com/Chevrotain/chevrotain/issues/1967

While the `types` field at the package.json root seems to work internally in the monorepo, other projects require to use the `exports.types` field.