### PR TITLE
Update api.d.ts to properly define `input`

### DIFF
--- a/packages/types/api.d.ts
+++ b/packages/types/api.d.ts
@@ -852,7 +852,8 @@ declare abstract class BaseParser {
     grammarPath: ITokenGrammarPath,
   ): TokenType[];
 
-  input: IToken[];
+  set input(value: IToken[]);
+  get input(): IToken[];
 
   /**
    * Will consume a single token and return the **next** token, meaning


### PR DESCRIPTION
## Explanation

Because `api.d.ts` incorrectly defines `input` as a data property instead of an [accessor property (as it's defined in code)](https://github.com/Chevrotain/chevrotain/blob/master/packages/chevrotain/src/parse/parser/traits/lexer_adapter.ts#L23-L40), then TypeScript will throw compilation errors if you try to override the parser's input accessor.

If you attempt to augment the Chevrotain types (with `declare module 'chevrotain'` and altering the interface), TypeScript will still fail, because the name exists, it's just incorrectly defined. The only workaround is to add a `@ts-ignore`. (Even `@ts-expect-error` will cause problems, because extensions like Volar cannot correctly determine that `tsc` will error in this case.)