### PR TITLE
Fixes #1982 - skips building errors / CST during backtracking

### DIFF
--- a/packages/chevrotain/src/parse/parser/parser.ts
+++ b/packages/chevrotain/src/parse/parser/parser.ts
@@ -13,7 +13,6 @@ import {
 import {
   CstNode,
   IParserConfig,
-  IRecognitionException,
   IRuleConfig,
   IToken,
   TokenType,
@@ -111,7 +110,6 @@ export interface IParserUnresolvedRefDefinitionError
 }
 
 export interface IParserState {
-  errors: IRecognitionException[];
   lexerState: any;
   RULE_STACK: number[];
   CST_STACK: CstNode[];

--- a/packages/chevrotain/src/parse/parser/traits/error_handler.ts
+++ b/packages/chevrotain/src/parse/parser/traits/error_handler.ts
@@ -17,6 +17,7 @@ import {
 import { MixedInParser } from "./parser_traits.js";
 import { DEFAULT_PARSER_CONFIG } from "../parser.js";
 
+const BACKTRACKING_ERROR = "Error during backtracking attempt";
 /**
  * Trait responsible for runtime parsing errors.
  */
@@ -64,6 +65,9 @@ export class ErrorHandler {
     prodType: PROD_TYPE,
     userDefinedErrMsg: string | undefined,
   ): never {
+    if (this.isBackTracking()) {
+      throw new EarlyExitException(BACKTRACKING_ERROR, this.LA(1), this.LA(0));
+    }
     const ruleName = this.getCurrRuleFullName();
     const ruleGrammar = this.getGAstProductions()[ruleName];
     const lookAheadPathsPerAlternative = getLookaheadPathsForOptionalProd(
@@ -94,6 +98,13 @@ export class ErrorHandler {
     occurrence: number,
     errMsgTypes: string | undefined,
   ): never {
+    if (this.isBackTracking()) {
+      throw new NoViableAltException(
+        BACKTRACKING_ERROR,
+        this.LA(1),
+        this.LA(0),
+      );
+    }
     const ruleName = this.getCurrRuleFullName();
     const ruleGrammar = this.getGAstProductions()[ruleName];
     // TODO: getLookaheadPathsForOr can be slow for large enough maxLookahead and certain grammars, consider caching ?

--- a/packages/chevrotain/src/parse/parser/traits/recognizer_engine.ts
+++ b/packages/chevrotain/src/parse/parser/traits/recognizer_engine.ts
@@ -693,18 +693,24 @@ export class RecognizerEngine {
     options?: SubruleMethodOpts<ARGS>,
   ): R {
     let ruleResult;
+    const isBackTracking = this.isBackTracking();
     try {
       const args = options !== undefined ? options.ARGS : undefined;
       this.subruleIdx = idx;
       ruleResult = ruleToCall.apply(this, args);
-      this.cstPostNonTerminal(
-        ruleResult,
-        options !== undefined && options.LABEL !== undefined
-          ? options.LABEL
-          : ruleToCall.ruleName,
-      );
+      if (!isBackTracking) {
+        this.cstPostNonTerminal(
+          ruleResult,
+          options !== undefined && options.LABEL !== undefined
+            ? options.LABEL
+            : ruleToCall.ruleName,
+        );
+      }
       return ruleResult;
     } catch (e) {
+      if (isBackTracking) {
+        throw e;
+      }
       throw this.subruleInternalError(e, options, ruleToCall.ruleName);
     }
   }

--- a/packages/chevrotain/src/parse/parser/traits/recognizer_engine.ts
+++ b/packages/chevrotain/src/parse/parser/traits/recognizer_engine.ts
@@ -732,7 +732,6 @@ export class RecognizerEngine {
     options: ConsumeMethodOpts | undefined,
   ): IToken {
     let consumedToken!: IToken;
-    const isBackTracking = this.isBackTracking();
     let backtrackingError!: Error;
     try {
       const nextToken = this.LA(1);
@@ -740,7 +739,7 @@ export class RecognizerEngine {
         this.consumeToken();
         consumedToken = nextToken;
       } else {
-        if (isBackTracking) {
+        if (this.isBackTracking()) {
           backtrackingError = new Error();
           backtrackingError.name = "MismatchedTokenException";
           throw backtrackingError;


### PR DESCRIPTION
Related to #1982.

I looked at the `benchmark_web` section, but I couldn't get that to work, and I don't think any of the examples have backtracking anyway.

I'm going to try this with my local parser for performance improvements.