### PR TITLE
Discourage people from considering PEG.js

### DIFF
--- a/performance/index.html
+++ b/performance/index.html
@@ -63,7 +63,7 @@
                 </p></li>
 
                 <li><p>
-                    <a rel="nofollow" href="http://pegjs.org/">PEG.js</a> Parser Generator
+                    <i>abandoned:</i> <s><a rel="nofollow" href="https://github.com/pegjs/pegjs">PEG.js</a> Parser Generator</s>
                     <a rel="nofollow"
                        href="https://github.com/Chevrotain/chevrotain/blob/gh-pages/performance/jsonParsers/pegjs/json.pegjs">grammar</a>
                     ->


### PR DESCRIPTION
As of 2024-03-16, https://pegjs.org no longer hosts content related to the PEG.js project -- see https://web.archive.org/web/20240316193229/https://pegjs.org/

* https://github.com/pegjs/pegjs/issues/639
* https://github.com/pegjs/pegjs/issues/675