### PR TITLE
Adds lookbehind support

### DIFF
--- a/packages/chevrotain/src/scan/reg_exp.ts
+++ b/packages/chevrotain/src/scan/reg_exp.ts
@@ -263,7 +263,7 @@ class CharCodeFinder extends BaseRegExpVisitor {
       return;
     }
 
-    // switch lookaheads as they do not actually consume any characters thus
+    // switch lookaheads / lookbehinds as they do not actually consume any characters thus
     // finding a charCode at lookahead context does not mean that regexp can actually contain it in a match.
     switch (node.type) {
       case "Lookahead":
@@ -272,7 +272,13 @@ class CharCodeFinder extends BaseRegExpVisitor {
       case "NegativeLookahead":
         this.visitNegativeLookahead(node);
         return;
-    }
+      case "Lookbehind":
+        this.visitLookbehind(node);
+        return;
+      case "NegativeLookbehind":
+        this.visitNegativeLookbehind(node);
+        return;
+      }
 
     super.visitChildren(node);
   }

--- a/packages/regexp-to-ast/src/base-regexp-visitor.ts
+++ b/packages/regexp-to-ast/src/base-regexp-visitor.ts
@@ -62,6 +62,12 @@ export class BaseRegExpVisitor {
       case "NegativeLookahead":
         this.visitNegativeLookahead(node);
         break;
+      case "Lookbehind":
+        this.visitLookbehind(node);
+        break;
+      case "NegativeLookbehind":
+        this.visitNegativeLookbehind(node);
+        break;
       case "Character":
         this.visitCharacter(node);
         break;
@@ -102,6 +108,10 @@ export class BaseRegExpVisitor {
   public visitLookahead(node: Assertion): void {}
 
   public visitNegativeLookahead(node: Assertion): void {}
+
+  public visitLookbehind(node: Assertion): void {}
+
+  public visitNegativeLookbehind(node: Assertion): void {}
 
   // atoms
   public visitCharacter(node: Character): void {}

--- a/packages/regexp-to-ast/test/parser.spec.ts
+++ b/packages/regexp-to-ast/test/parser.spec.ts
@@ -469,6 +469,97 @@ describe("The RegExp to Ast parser", () => {
       });
     });
 
+    it("lookbehind assertion", () => {
+      const ast = parser.pattern("/a(?<=b)/");
+      expect(ast.value).to.deep.equal({
+        type: "Disjunction",
+        loc: { begin: 1, end: 7 },
+        value: [
+          {
+            type: "Alternative",
+            loc: { begin: 1, end: 7 },
+            value: [
+              {
+                type: "Character",
+                loc: { begin: 1, end: 2 },
+                value: 97,
+              },
+              {
+                type: "Lookbehind",
+                loc: { begin: 2, end: 7 },
+                value: {
+                  type: "Disjunction",
+                  loc: { begin: 5, end: 6 },
+                  value: [
+                    {
+                      type: "Alternative",
+                      loc: { begin: 5, end: 6 },
+                      value: [
+                        {
+                          type: "Character",
+                          loc: {
+                            begin: 5,
+                            end: 6,
+                          },
+                          value: 98,
+                        },
+                      ],
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      });
+    });
+
+    it("lookbehind assertion", () => {
+      const ast = parser.pattern("/a(?<!b)/");
+      expect(ast.value).to.deep.equal({
+        type: "Disjunction",
+        loc: { begin: 1, end: 7 },
+        value: [
+          {
+            type: "Alternative",
+            loc: { begin: 1, end: 7 },
+            value: [
+              {
+                type: "Character",
+                loc: { begin: 1, end: 2 },
+                value: 97,
+              },
+              {
+                type: "NegativeLookbehind",
+                loc: { begin: 2, end: 7 },
+                value: {
+                  type: "Disjunction",
+                  loc: { begin: 5, end: 6 },
+                  value: [
+                    {
+                      type: "Alternative",
+                      loc: { begin: 5, end: 6 },
+                      value: [
+                        {
+                          type: "Character",
+                          loc: {
+                            begin: 5,
+                            end: 6,
+                          },
+                          value: 98,
+                        },
+                      ],
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      });
+    });
+  });
+
     context("quantifiers", () => {
       it("zero or one", () => {
         const ast = parser.pattern("/a?/");

--- a/packages/regexp-to-ast/test/visitor.spec.ts
+++ b/packages/regexp-to-ast/test/visitor.spec.ts
@@ -138,6 +138,31 @@ describe("The regexp AST visitor", () => {
     new NegativeLookaheadVisitor().visit(ast);
   });
 
+
+  it("Can visit Lookbehind", () => {
+    const ast = parser.pattern("/a(?<=a|b)/");
+    class LookbehindVisitor extends BaseRegExpVisitor {
+      visitLookbehind(node: Assertion) {
+        super.visitLookbehind(node);
+        expect(node.value?.value).to.have.lengthOf(2);
+      }
+    }
+
+    new LookbehindVisitor().visit(ast);
+  });
+
+  it("Can visit NegativeLookbehind", () => {
+    const ast = parser.pattern("/a(?<!a|b|c)/");
+    class NegativeLookbehindVisitor extends BaseRegExpVisitor {
+      visitNegativeLookbehind(node: Assertion) {
+        super.visitNegativeLookbehind(node);
+        expect(node.value!.value).to.have.lengthOf(3);
+      }
+    }
+
+    new NegativeLookbehindVisitor().visit(ast);
+  });
+
   it("Can visit Character", () => {
     const ast = parser.pattern("/a/");
     class CharacterVisitor extends BaseRegExpVisitor {

--- a/packages/regexp-to-ast/types.d.ts
+++ b/packages/regexp-to-ast/types.d.ts
@@ -55,7 +55,9 @@ export interface Assertion extends IRegExpAST {
     | "WordBoundary"
     | "NonWordBoundary"
     | "Lookahead"
-    | "NegativeLookahead";
+    | "NegativeLookahead"
+    | "Lookbehind"
+    | "NegativeLookbehind";
 
   value?: Disjunction;
 }
@@ -126,6 +128,8 @@ export class BaseRegExpVisitor {
   visitNonWordBoundary(node: Assertion): void;
   visitLookahead(node: Assertion): void;
   visitNegativeLookahead(node: Assertion): void;
+  visitLookbehind(node: Assertion): void;
+  visitNegativeLookbehind(node: Assertion): void;
   visitCharacter(node: Character): void;
   visitSet(node: Set): void;
   visitGroup(Node: Group): void;


### PR DESCRIPTION
This PR attempts to fix a warning that occurs when using lookbehind expressions within tokens:

```
Error: Unable to use "first char" lexer optimizations:

	Failed parsing: < /(?<=[:=<>])[a-zA-Z_]\w*(?=[:=<>])/ >
	Using the @chevrotain/regexp-to-ast library
	Please open an issue at: https://github.com/chevrotain/chevrotain/issues
```

Ref: https://github.com/bd82/regexp-to-ast/pull/84
Ref: https://github.com/bd82/regexp-to-ast/pull/129
