### PR TITLE
feat: optimize unoptimizable token types

### DIFF
--- a/packages/chevrotain/test/scan/lexer_spec.ts
+++ b/packages/chevrotain/test/scan/lexer_spec.ts
@@ -2236,6 +2236,7 @@ describe("debugging and messages and optimizations", () => {
     });
     expect((<any>alphaLexerSafeMode).charCodeToPatternIdxToConfig.defaultMode)
       .to.be.empty;
+    const safeModeResult = alphaLexerSafeMode.tokenize("a");
 
     // compare to safeMode disabled
     const alphaLexerNoSafeMode = new Lexer([Alpha], {
@@ -2245,6 +2246,106 @@ describe("debugging and messages and optimizations", () => {
       (<any>alphaLexerNoSafeMode).charCodeToPatternIdxToConfig
         .defaultMode[97][0].tokenType,
     ).to.equal(Alpha);
+    const noSafeModeResult = alphaLexerNoSafeMode.tokenize("a");
+    expect(safeModeResult).to.deep.equal(noSafeModeResult);
+  });
+
+  it("won't optimize with safe mode enabled - multi mode lexer", () => {
+    const Alpha = createToken({
+      name: "A",
+      pattern: /a/,
+      push_mode: "b",
+    });
+    const Beta = createToken({
+      name: "B",
+      pattern: /b/,
+      pop_mode: true,
+    });
+    const tokens = {
+      modes: {
+        a: [Alpha],
+        b: [Beta],
+      },
+      defaultMode: "a",
+    };
+    const text = "abab";
+    const lexerSafeMode = new Lexer(tokens, {
+      positionTracking: "onlyOffset",
+      safeMode: true,
+    });
+    expect((<any>lexerSafeMode).charCodeToPatternIdxToConfig.a).to.be.empty;
+    const safeModeResult = lexerSafeMode.tokenize(text);
+
+    // compare to safeMode disabled
+    const lexerNoSafeMode = new Lexer(tokens, {
+      positionTracking: "onlyOffset",
+    });
+    expect(
+      (<any>lexerNoSafeMode).charCodeToPatternIdxToConfig.a[97][0].tokenType,
+    ).to.equal(Alpha);
+    const noSafeModeResult = lexerNoSafeMode.tokenize(text);
+    expect(safeModeResult).to.deep.equal(noSafeModeResult);
+  });
+
+  context("lexer optimization", () => {
+    const dFunction = (text: string, offset: number) => {
+      if (text.charAt(offset) === "d") {
+        return ["d"] as [string];
+      } else {
+        return null;
+      }
+    };
+
+    for (const [name, pattern] of [
+      ["function", dFunction],
+      ["unicode regexp", /d/u],
+      ["lookbehind regexp", /(?<!a)d/],
+    ]) {
+      it(`will optimize ${name} pattern`, () => {
+        const Alpha = createToken({
+          name: "A",
+          pattern: "a",
+        });
+        const Beta = createToken({
+          name: "B",
+          pattern: "b",
+        });
+        const Delta = createToken({
+          name: "D",
+          pattern,
+        });
+        const optimizedLexer = new Lexer([Alpha, Delta, Beta], {
+          positionTracking: "onlyOffset",
+        });
+        // Assert that the pattern will be added to all character codes
+        // Also assert that the ordering gets preserved
+        expect(
+          (<any>optimizedLexer).charCodeToPatternIdxToConfig.defaultMode[
+            "a".charCodeAt(0)
+          ].map((e: any) => e.tokenType),
+        ).to.deep.equal([Alpha, Delta]);
+        expect(
+          (<any>optimizedLexer).charCodeToPatternIdxToConfig.defaultMode[
+            "b".charCodeAt(0)
+          ].map((e: any) => e.tokenType),
+        ).to.deep.equal([Delta, Beta]);
+        // The lexer cannot identify that the pattern is only for the character 'd'
+        expect(
+          (<any>optimizedLexer).charCodeToPatternIdxToConfig.defaultMode[
+            "d".charCodeAt(0)
+          ],
+        ).to.be.undefined;
+        expect(optimizedLexer.tokenize("a").tokens[0].tokenType).to.deep.equal(
+          Alpha,
+        );
+        expect(optimizedLexer.tokenize("b").tokens[0].tokenType).to.deep.equal(
+          Beta,
+        );
+        expect(optimizedLexer.tokenize("d").tokens[0].tokenType).to.deep.equal(
+          Delta,
+        );
+      });
+    }
   });
 });
 


### PR DESCRIPTION
Currently, when the lexer cannot apply the "first character" optimization to *any* token type, it will use an un-optimized algorithm for *all* token types. This behavior can also be seen when using the `safeMode: true` property on lexers. While this definitely makes sense in general, this leads to major performance regressions (possibly in the order of magnitudes) in case the token type cannot be equipped with the `start_chars_hint` field (like for unicode regexp).

This PR applies a major optimization in case the "first character" optimization fails: When encountering a non-optimizable token type the lexer will now attempt to match this token type on any tokenization attempt in addition to the optimized token types. More generally, the lexer will attempt all non-optimizable token types together with the optimized token types in the order in which they appear (this is important as we likely get unexpected behavior otherwise!).

If there is no optimized token type for the character at the current position, the lexer will now attempt to match all non-optimizable token types, only yielding a lexer error in case non of them match.

This new behavior mirrors the current behavior perfectly, and none of the existing tests can actually determine that something has changed in the lexer behavior. This change is a pure performance improvement for non-optimizable token types. Of course I added new tests to assert that the new change behaves as expected. Furthermore, using `ensureOptimizations: true` when creating a lexer still throws an error when attempting to use non-optimizable tokens, as it's not a perfect optimization (the best optimization is still to use the `start_chars_hint` for those tokens).

I haven't written a benchmark for Chevrotain yet to tell whether this yields the expected performance improvements for non-optimizable tokens, but I can already tell that it does not decrease performance for the normal use case (I'm not sure why the performance for JSON increases, I believe the first test that I run is always a bit slower, even when running everything multiple times):

![image](https://github.com/user-attachments/assets/92951a62-54f3-48dd-94a8-c491a0da7906)