### PR TITLE
feat: add current lexer mode to buildUnexpectedCharactersMessage

### DIFF
--- a/examples/lexer/custom_errors/custom_errors.js
+++ b/examples/lexer/custom_errors/custom_errors.js
@@ -20,6 +20,8 @@ const OyVeyErrorMessageProvider = {
     line,
     // eslint-disable-next-line  no-unused-vars -- template
     column,
+    // eslint-disable-next-line  no-unused-vars -- template
+    mode,
   ) {
     return (
       `Oy Vey!!! unexpected character: ->${fullText.charAt(

--- a/packages/chevrotain/src/scan/lexer_errors_public.ts
+++ b/packages/chevrotain/src/scan/lexer_errors_public.ts
@@ -11,6 +11,7 @@ export const defaultLexerErrorProvider: ILexerErrorMessageProvider = {
     length: number,
     line?: number,
     column?: number,
+    mode?: string,
   ): string {
     return (
       `unexpected character: ->${fullText.charAt(

--- a/packages/chevrotain/src/scan/lexer_public.ts
+++ b/packages/chevrotain/src/scan/lexer_public.ts
@@ -740,6 +740,7 @@ export class Lexer {
           errLength,
           errorLine,
           errorColumn,
+          last(modeStack),
         );
         errors.push({
           offset: errorStartOffset,

--- a/packages/chevrotain/test/scan/lexer_errors_public_spec.ts
+++ b/packages/chevrotain/test/scan/lexer_errors_public_spec.ts
@@ -11,6 +11,7 @@ describe("The Chevrotain default lexer error message provider", () => {
       1,
       0,
       23,
+      "example_mode",
     );
 
     expect(msg).to.equal(

--- a/packages/chevrotain/test/scan/lexer_spec.ts
+++ b/packages/chevrotain/test/scan/lexer_spec.ts
@@ -2020,10 +2020,11 @@ function defineLexerSpecs(
               length: number,
               line?: number,
               column?: number,
+              mode?: string,
             ): string {
               return `[${line}, ${column}] Unknown character ${fullText.charAt(
                 startOffset,
-              )} at position ${startOffset} skipped ${length}`;
+              )} at position ${startOffset} skipped ${length} (mode ${mode})`;
             },
           };
 
@@ -2036,7 +2037,7 @@ function defineLexerSpecs(
             const lexResult = ModeLexerWithCustomErrors.tokenize(input);
             expect(lexResult.errors).to.have.lengthOf(1);
             expect(lexResult.errors[0].message).to.equal(
-              "[1, 24] Unknown character + at position 23 skipped 1",
+              "[1, 24] Unknown character + at position 23 skipped 1 (mode numbers)",
             );
           });
 

--- a/packages/types/api.d.ts
+++ b/packages/types/api.d.ts
@@ -1395,6 +1395,8 @@ export interface ILexerErrorMessageProvider {
    *
    * @param column - Column number where the error occurred. (optional)
    *                    Will not be provided when lexer is not defined to track lines/columns
+   *
+   * @param mode - The current lexer mode.
    */
   buildUnexpectedCharactersMessage(
     fullText: string,
@@ -1402,6 +1404,7 @@ export interface ILexerErrorMessageProvider {
     length: number,
     line?: number,
     column?: number,
+    mode?: string,
   ): string;
 
   /**


### PR DESCRIPTION
As discussed in #2078 

Note: even though the mode will always be provided, I declared it as `mode?: string` to avoid breaking changes.
Other options would include
- putting the mode parameter before the optional line and column parameters
- changing the declaration of line and column from `line?: number` to `line: number | undefined`

Both of these would be breaking changes. If you prefer any of these options, just let me know