### PR TITLE
fix: missing package.json meta for require

### DIFF
--- a/packages/chevrotain/package.json
+++ b/packages/chevrotain/package.json
@@ -27,6 +27,7 @@
   "exports": {
     ".": {
       "import": "./lib/src/api.js",
+      "require": "./lib/src/api.js",
       "types": "./chevrotain.d.ts"
     }
   },


### PR DESCRIPTION
- Only works on modern versions of nodejs
- Chevrotain is still ESM only, the compatibility is at the nodejs level.
- https://nodejs.org/api/modules.html#loading-ecmascript-modules-using-require

resolves ##2018