### PR TITLE
feat: optimize unoptimizable token types (#2072)

### DIFF
--- a/packages/chevrotain/src/scan/lexer.ts
+++ b/packages/chevrotain/src/scan/lexer.ts
@@ -66,6 +66,7 @@ export interface IAnalyzeResult {
   emptyGroups: { [groupName: string]: IToken[] };
   hasCustom: boolean;
   canBeOptimized: boolean;
+  unoptimizedPatterns: IPatternConfig[];
 }
 
 export let SUPPORT_STICKY =
@@ -306,6 +307,7 @@ export function analyzeTokenTypes(
   });
 
   let canBeOptimized = true;
+  let unoptimizedPatterns: IPatternConfig[] = [];
   let charCodeToPatternIdxToConfig: { [charCode: number]: IPatternConfig[] } =
     [];
 
@@ -317,7 +319,12 @@ export function analyzeTokenTypes(
           if (typeof currTokType.PATTERN === "string") {
             const charCode = currTokType.PATTERN.charCodeAt(0);
             const optimizedIdx = charCodeToOptimizedIndex(charCode);
-            addToMapOfArrays(result, optimizedIdx, patternIdxToConfig[idx]);
+            addToMapOfArrays(
+              result,
+              optimizedIdx,
+              patternIdxToConfig[idx],
+              unoptimizedPatterns,
+            );
           } else if (isArray(currTokType.START_CHARS_HINT)) {
             let lastOptimizedIdx: number;
             forEach(currTokType.START_CHARS_HINT, (charOrInt) => {
@@ -336,21 +343,31 @@ export function analyzeTokenTypes(
                   result,
                   currOptimizedIdx,
                   patternIdxToConfig[idx],
+                  unoptimizedPatterns,
                 );
               }
             });
           } else if (isRegExp(currTokType.PATTERN)) {
             if (currTokType.PATTERN.unicode) {
-              canBeOptimized = false;
+              forEach(Object.keys(result), (code) => {
+                addToMapOfArrays(
+                  result,
+                  Number(code),
+                  patternIdxToConfig[idx],
+                  unoptimizedPatterns,
+                );
+              });
+              unoptimizedPatterns.push(patternIdxToConfig[idx]);
               if (options.ensureOptimizations) {
                 PRINT_ERROR(
                   `${failedOptimizationPrefixMsg}` +
                     `\tUnable to analyze < ${currTokType.PATTERN.toString()} > pattern.\n` +
                     "\tThe regexp unicode flag is not currently supported by the regexp-to-ast library.\n" +
-                    "\tThis will disable the lexer's first char optimizations.\n" +
+                    "\tThis reduces lexer performance.\n" +
                     "\tFor details See: https://chevrotain.io/docs/guide/resolving_lexer_errors.html#UNICODE_OPTIMIZE",
                 );
               }
+              canBeOptimized = false;
             } else {
               const optimizedCodes = getOptimizedStartCodesIndices(
                 currTokType.PATTERN,
@@ -358,27 +375,49 @@ export function analyzeTokenTypes(
               );
               /* istanbul ignore if */
               // start code will only be empty given an empty regExp or failure of regexp-to-ast library
-              // the first should be a different validation and the second cannot be tested.
               if (isEmpty(optimizedCodes)) {
                 // we cannot understand what codes may start possible matches
-                // The optimization correctness requires knowing start codes for ALL patterns.
-                // Not actually sure this is an error, no debug message
+                // instead, simply add the token to all known start characters
+                forEach(Object.keys(result), (code) => {
+                  addToMapOfArrays(
+                    result,
+                    Number(code),
+                    patternIdxToConfig[idx],
+                    unoptimizedPatterns,
+                  );
+                });
+                unoptimizedPatterns.push(patternIdxToConfig[idx]);
                 canBeOptimized = false;
+              } else {
+                forEach(optimizedCodes, (code) => {
+                  addToMapOfArrays(
+                    result,
+                    code,
+                    patternIdxToConfig[idx],
+                    unoptimizedPatterns,
+                  );
+                });
               }
-              forEach(optimizedCodes, (code) => {
-                addToMapOfArrays(result, code, patternIdxToConfig[idx]);
-              });
             }
           } else {
             if (options.ensureOptimizations) {
               PRINT_ERROR(
                 `${failedOptimizationPrefixMsg}` +
                   `\tTokenType: <${currTokType.name}> is using a custom token pattern without providing <start_chars_hint> parameter.\n` +
-                  "\tThis will disable the lexer's first char optimizations.\n" +
+                  "\tThis reduces lexer performance.\n" +
                   "\tFor details See: https://chevrotain.io/docs/guide/resolving_lexer_errors.html#CUSTOM_OPTIMIZE",
               );
             }
             canBeOptimized = false;
+            forEach(Object.keys(result), (code) => {
+              addToMapOfArrays(
+                result,
+                Number(code),
+                patternIdxToConfig[idx],
+                unoptimizedPatterns,
+              );
+            });
+            unoptimizedPatterns.push(patternIdxToConfig[idx]);
           }
 
           return result;
@@ -389,11 +428,12 @@ export function analyzeTokenTypes(
   }
 
   return {
-    emptyGroups: emptyGroups,
-    patternIdxToConfig: patternIdxToConfig,
-    charCodeToPatternIdxToConfig: charCodeToPatternIdxToConfig,
-    hasCustom: hasCustom,
-    canBeOptimized: canBeOptimized,
+    emptyGroups,
+    patternIdxToConfig,
+    charCodeToPatternIdxToConfig,
+    hasCustom,
+    canBeOptimized,
+    unoptimizedPatterns,
   };
 }
 
@@ -1135,9 +1175,10 @@ function addToMapOfArrays<T>(
   map: Record<number, T[]>,
   key: number,
   value: T,
+  initial: T[],
 ): void {
   if (map[key] === undefined) {
-    map[key] = [value];
+    map[key] = [...initial, value];
   } else {
     map[key].push(value);
   }

--- a/packages/chevrotain/test/scan/lexer_spec.ts
+++ b/packages/chevrotain/test/scan/lexer_spec.ts
@@ -2305,9 +2305,8 @@ describe("debugging and messages and optimizations", () => {
     for (const [name, pattern] of [
       ["function", dFunction],
       ["unicode regexp", /d/u],
-      ["lookbehind regexp", /(?<!a)d/],
     ]) {
-      it(`will optimize ${name} pattern`, () => {
+      it(`will (partially) optimize ${name} pattern`, () => {
         const Alpha = createToken({
           name: "A",
           pattern: "a",

--- a/packages/chevrotain/test/scan/lexer_spec.ts
+++ b/packages/chevrotain/test/scan/lexer_spec.ts
@@ -2242,6 +2242,7 @@ describe("debugging and messages and optimizations", () => {
     });
     expect((<any>alphaLexerSafeMode).charCodeToPatternIdxToConfig.defaultMode)
       .to.be.empty;
+    const safeModeResult = alphaLexerSafeMode.tokenize("a");
 
     // compare to safeMode disabled
     const alphaLexerNoSafeMode = new Lexer([Alpha], {
@@ -2251,6 +2252,106 @@ describe("debugging and messages and optimizations", () => {
       (<any>alphaLexerNoSafeMode).charCodeToPatternIdxToConfig
         .defaultMode[97][0].tokenType,
     ).to.equal(Alpha);
+    const noSafeModeResult = alphaLexerNoSafeMode.tokenize("a");
+    expect(safeModeResult).to.deep.equal(noSafeModeResult);
+  });
+
+  it("won't optimize with safe mode enabled - multi mode lexer", () => {
+    const Alpha = createToken({
+      name: "A",
+      pattern: /a/,
+      push_mode: "b",
+    });
+    const Beta = createToken({
+      name: "B",
+      pattern: /b/,
+      pop_mode: true,
+    });
+    const tokens = {
+      modes: {
+        a: [Alpha],
+        b: [Beta],
+      },
+      defaultMode: "a",
+    };
+    const text = "abab";
+    const lexerSafeMode = new Lexer(tokens, {
+      positionTracking: "onlyOffset",
+      safeMode: true,
+    });
+    expect((<any>lexerSafeMode).charCodeToPatternIdxToConfig.a).to.be.empty;
+    const safeModeResult = lexerSafeMode.tokenize(text);
+
+    // compare to safeMode disabled
+    const lexerNoSafeMode = new Lexer(tokens, {
+      positionTracking: "onlyOffset",
+    });
+    expect(
+      (<any>lexerNoSafeMode).charCodeToPatternIdxToConfig.a[97][0].tokenType,
+    ).to.equal(Alpha);
+    const noSafeModeResult = lexerNoSafeMode.tokenize(text);
+    expect(safeModeResult).to.deep.equal(noSafeModeResult);
+  });
+
+  context("lexer optimization", () => {
+    const dFunction = (text: string, offset: number) => {
+      if (text.charAt(offset) === "d") {
+        return ["d"] as [string];
+      } else {
+        return null;
+      }
+    };
+
+    for (const [name, pattern] of [
+      ["function", dFunction],
+      ["unicode regexp", /d/u],
+      ["lookbehind regexp", /(?<!a)d/],
+    ]) {
+      it(`will optimize ${name} pattern`, () => {
+        const Alpha = createToken({
+          name: "A",
+          pattern: "a",
+        });
+        const Beta = createToken({
+          name: "B",
+          pattern: "b",
+        });
+        const Delta = createToken({
+          name: "D",
+          pattern,
+        });
+        const optimizedLexer = new Lexer([Alpha, Delta, Beta], {
+          positionTracking: "onlyOffset",
+        });
+        // Assert that the pattern will be added to all character codes
+        // Also assert that the ordering gets preserved
+        expect(
+          (<any>optimizedLexer).charCodeToPatternIdxToConfig.defaultMode[
+            "a".charCodeAt(0)
+          ].map((e: any) => e.tokenType),
+        ).to.deep.equal([Alpha, Delta]);
+        expect(
+          (<any>optimizedLexer).charCodeToPatternIdxToConfig.defaultMode[
+            "b".charCodeAt(0)
+          ].map((e: any) => e.tokenType),
+        ).to.deep.equal([Delta, Beta]);
+        // The lexer cannot identify that the pattern is only for the character 'd'
+        expect(
+          (<any>optimizedLexer).charCodeToPatternIdxToConfig.defaultMode[
+            "d".charCodeAt(0)
+          ],
+        ).to.be.undefined;
+        expect(optimizedLexer.tokenize("a").tokens[0].tokenType).to.deep.equal(
+          Alpha,
+        );
+        expect(optimizedLexer.tokenize("b").tokens[0].tokenType).to.deep.equal(
+          Beta,
+        );
+        expect(optimizedLexer.tokenize("d").tokens[0].tokenType).to.deep.equal(
+          Delta,
+        );
+      });
+    }
   });
 });
 


### PR DESCRIPTION
TODO:

- [ ] Code Review
- [ ] Verify if any more docs need to be updated regarding lexer optimizations / performance (reduce vs full disabling of optimizations)
- [x] Should not test case ` ["lookbehind regexp", /(?<!a)d/]` fail now that regexp-to-ast supports lookbehind syntax?
       - Because lookbehind support was not merged (https://github.com/Chevrotain/chevrotain/pull/2134)
       - test case fails as expected and was removed as it is no longer relevant.
- [x] Verify no performance regressions
  - There may be a **small regression** in the more complex CSS lexer
  - <img width="1154" height="666" alt="image" src="https://github.com/user-attachments/assets/0a05909d-a553-414c-a470-a6f98736598a" />
  - But it may be worth "paying" for avoiding a major regression anytime there is an UN-optimizeable token pattern.
