### PR TITLE
feat: expose `currCSTNode` API to access the current CstNode

### DIFF
--- a/packages/chevrotain/src/parse/parser/traits/tree_builder.ts
+++ b/packages/chevrotain/src/parse/parser/traits/tree_builder.ts
@@ -226,6 +226,12 @@ export class TreeBuilder {
     this.setNodeLocationFromNode(preCstNode.location!, ruleCstResult.location!);
   }
 
+  get currCSTNode(): CstNode {
+    // casting to unknown because: `TS2784: get and set accessors cannot declare this parameters.`
+    const mixedIn = this as unknown as MixedInParser;
+    return mixedIn.CST_STACK[mixedIn.CST_STACK.length - 1];
+  }
+
   getBaseCstVisitorConstructor<IN = any, OUT = any>(
     this: MixedInParser,
   ): {

--- a/packages/chevrotain/test/parse/cst_spec.ts
+++ b/packages/chevrotain/test/parse/cst_spec.ts
@@ -669,6 +669,70 @@ function defineTestSuite(recoveryMode: boolean) {
       expect(cst.location).to.be.undefined;
     });
 
+    it("Can access the current CSTNode via currCSTNode", () => {
+      let capturedNodeInner: CstNode | undefined;
+      let capturedNodeOuter: CstNode | undefined;
+
+      class CurrCSTNodeParser extends CstParser {
+        constructor(input: IToken[] = []) {
+          super(ALL_TOKENS, { recoveryEnabled: recoveryMode });
+          this.performSelfAnalysis();
+          this.input = input;
+        }
+
+        public outerRule = this.RULE("outerRule", () => {
+          // Capture the current node at the start of the outer rule
+          capturedNodeOuter = this.currCSTNode;
+          this.CONSUME(A);
+          this.SUBRULE(this.innerRule);
+        });
+
+        public innerRule = this.RULE("innerRule", () => {
+          // Capture the current node at the start of the inner rule
+          capturedNodeInner = this.currCSTNode;
+          this.CONSUME(B);
+        });
+      }
+
+      const input = [createRegularToken(A), createRegularToken(B)];
+      const parser = new CurrCSTNodeParser(input);
+      const cst = parser.outerRule();
+
+      // The captured nodes should be the same objects as the returned CST nodes
+      expect(cst.name).to.equal("outerRule");
+      expect(capturedNodeOuter).to.equal(cst);
+
+      const innerCst = cst.children.innerRule[0] as CstNode;
+      expect(innerCst.name).to.equal("innerRule");
+      expect(capturedNodeInner).to.equal(innerCst);
+    });
+
+    it("Can attach custom properties to the current CSTNode via currCSTNode", () => {
+      class CurrCSTNodeCustomPropsParser extends CstParser {
+        constructor(input: IToken[] = []) {
+          super(ALL_TOKENS, { recoveryEnabled: recoveryMode });
+          this.performSelfAnalysis();
+          this.input = input;
+        }
+
+        public myRule = this.RULE("myRule", () => {
+          this.CONSUME(A);
+          this.CONSUME(B);
+          // Attach custom metadata to the CSTNode currently being built.
+          // ACTION() ensures this does not run during the grammar recording phase.
+          this.ACTION(() => {
+            (this.currCSTNode as any).customProp = "hello";
+          });
+        });
+      }
+
+      const input = [createRegularToken(A), createRegularToken(B)];
+      const parser = new CurrCSTNodeCustomPropsParser(input);
+      const cst = parser.myRule();
+
+      expect((cst as any).customProp).to.equal("hello");
+    });
+
     context("Error Recovery", () => {
       it("re-sync recovery", () => {
         class CstRecoveryParserReSync extends CstParser {

--- a/packages/types/api.d.ts
+++ b/packages/types/api.d.ts
@@ -868,6 +868,30 @@ declare abstract class BaseParser {
    * See: {@link BaseParser.LA}
    */
   protected LA_FAST(howMuch: number): IToken;
+
+  /**
+   * Returns the CstNode currently being built by the active rule.
+   *
+   * This allows accessing and modifying the current CST node from within
+   * a rule's implementation, without resorting to internal APIs.
+   *
+   * @example
+   * $.RULE("functionDecl", () => {
+   *   const startIdx = this.currIdx
+   *   $.CONSUME(FunctionKw)
+   *   $.CONSUME(Identifier)
+   *   $.CONSUME(LParen)
+   *   // ...
+   *   $.CONSUME(RParen)
+   *   // Attach the token vector range to the current CstNode for source mapping
+   *   this.ACTION(() => {
+   *     this.currCSTNode.tokVectorRange = { from: startIdx, to: this.currIdx }
+   *   })
+   * })
+   *
+   * Only available when the parser is configured to output CST (`CstParser`).
+   */
+  protected get currCSTNode(): CstNode;
 }
 
 /**

--- a/packages/website/docs/changes/CHANGELOG.md
+++ b/packages/website/docs/changes/CHANGELOG.md
@@ -1,3 +1,9 @@
+## X.Y.Z (INSERT_DATE_HERE)
+
+#### Minor Changes
+
+- [feat: expose `currCSTNode` API to access the current CstNode during parsing](https://github.com/Chevrotain/chevrotain/issues/1032)
+
 ## 12.0.0 (3-13-2026)
 
 #### Breaking Changes


### PR DESCRIPTION

resolves: #1032