### PR TITLE
fix(lexer): honor inherited token config metadata

### DIFF
--- a/packages/chevrotain/src/scan/lexer.ts
+++ b/packages/chevrotain/src/scan/lexer.ts
@@ -191,8 +191,8 @@ export function analyzeTokenTypes(
       (clazz: any) => clazz.PUSH_MODE,
     );
 
-    patternIdxToPopMode = onlyRelevantTypes.map((clazz: any) =>
-      Object.hasOwn(clazz, "POP_MODE"),
+    patternIdxToPopMode = onlyRelevantTypes.map(
+      (clazz: any) => clazz.POP_MODE === true,
     );
   });
 
@@ -204,7 +204,7 @@ export function analyzeTokenTypes(
     patternIdxToCanLineTerminator = onlyRelevantTypes.map((tokType) => false);
     if (options.positionTracking !== "onlyOffset") {
       patternIdxToCanLineTerminator = onlyRelevantTypes.map((tokType) => {
-        if (Object.hasOwn(tokType, "LINE_BREAKS")) {
+        if (tokType.LINE_BREAKS !== undefined) {
           return !!tokType.LINE_BREAKS;
         } else {
           return (
@@ -403,7 +403,7 @@ export function findMissingPatterns(
   tokenTypes: TokenType[],
 ): ILexerFilterResult {
   const tokenTypesWithMissingPattern = tokenTypes.filter((currType) => {
-    return !Object.hasOwn(currType, PATTERN);
+    return currType[PATTERN] == null;
   });
 
   const errors = tokenTypesWithMissingPattern.map((currType) => {
@@ -641,7 +641,7 @@ export function findInvalidGroupType(
   tokenTypes: TokenType[],
 ): ILexerDefinitionError[] {
   const invalidTypes = tokenTypes.filter((clazz: any) => {
-    if (!Object.hasOwn(clazz, "GROUP")) {
+    if (clazz.GROUP === undefined) {
       return false;
     }
     const group = clazz.GROUP;
@@ -849,7 +849,7 @@ export function performRuntimeChecks(
               `<${currModeName}> at index: <${currIdx}>\n`,
             type: LexerDefinitionErrorType.LEXER_DEFINITION_CANNOT_CONTAIN_UNDEFINED,
           });
-        } else if (Object.hasOwn(currTokType, "LONGER_ALT")) {
+        } else if (currTokType.LONGER_ALT !== undefined) {
           const longerAlt = Array.isArray(currTokType.LONGER_ALT)
             ? currTokType.LONGER_ALT
             : [currTokType.LONGER_ALT];
@@ -900,7 +900,7 @@ export function performWarningRuntimeChecks(
         warnings.push(warningDescriptor);
       } else {
         // we don't want to attempt to scan if the user explicitly specified the line_breaks option.
-        if (Object.hasOwn(tokType, "LINE_BREAKS")) {
+        if (tokType.LINE_BREAKS !== undefined) {
           if (tokType.LINE_BREAKS === true) {
             hasAnyLineBreak = true;
           }
@@ -1014,7 +1014,7 @@ function checkLineBreaksIssues(
       errMsg?: string;
     }
   | false {
-  if (Object.hasOwn(tokType, "LINE_BREAKS")) {
+  if (tokType.LINE_BREAKS !== undefined) {
     // if the user explicitly declared the line_breaks option we will respect their choice
     // and assume it is correct.
     return false;

--- a/packages/chevrotain/src/scan/tokens_public.ts
+++ b/packages/chevrotain/src/scan/tokens_public.ts
@@ -20,77 +20,47 @@ export function hasTokenLabel(
   return typeof obj.LABEL === "string" && obj.LABEL !== "";
 }
 
-const PARENT = "parent";
-const CATEGORIES = "categories";
-const LABEL = "label";
-const GROUP = "group";
-const PUSH_MODE = "push_mode";
-const POP_MODE = "pop_mode";
-const LONGER_ALT = "longer_alt";
-const LINE_BREAKS = "line_breaks";
-const START_CHARS_HINT = "start_chars_hint";
-
+/**
+ * Creates a TokenType with every public config field pre-declared so tokens
+ * produced by createToken() share a stable base object shape from birth.
+ *
+ * Validators in lexer.ts that used Object.hasOwn() to detect "was this field
+ * explicitly configured?" are updated to check `!== undefined` instead.
+ */
 export function createToken(config: ITokenConfig): TokenType {
-  return createTokenInternal(config);
-}
-
-function createTokenInternal(config: ITokenConfig): TokenType {
-  const pattern = config.pattern;
-
-  const tokenType: TokenType = <any>{};
-  tokenType.name = config.name;
-
-  if (pattern !== undefined) {
-    tokenType.PATTERN = pattern;
-  }
-
-  if (Object.hasOwn(config, PARENT)) {
+  if (Object.hasOwn(config, "parent")) {
     throw (
       "The parent property is no longer supported.\n" +
       "See: https://github.com/chevrotain/chevrotain/issues/564#issuecomment-349062346 for details."
     );
   }
 
-  if (Object.hasOwn(config, CATEGORIES)) {
-    // casting to ANY as this will be fixed inside `augmentTokenTypes``
-    tokenType.CATEGORIES = <any>config[CATEGORIES];
-  }
+  const rawCats = config.categories;
+  const categories: TokenType[] = rawCats
+    ? Array.isArray(rawCats)
+      ? (rawCats as TokenType[])
+      : [rawCats as TokenType]
+    : [];
+
+  const tokenType: TokenType = {
+    name: config.name,
+    PATTERN: config.pattern ?? undefined,
+    LABEL: config.label ?? undefined,
+    GROUP: config.group ?? undefined,
+    PUSH_MODE: config.push_mode ?? undefined,
+    POP_MODE: config.pop_mode ?? undefined,
+    LONGER_ALT: config.longer_alt ?? undefined,
+    LINE_BREAKS: config.line_breaks ?? undefined,
+    START_CHARS_HINT: config.start_chars_hint ?? undefined,
+    CATEGORIES: categories,
+  } as unknown as TokenType;
 
   augmentTokenTypes([tokenType]);
-
-  if (Object.hasOwn(config, LABEL)) {
-    tokenType.LABEL = config[LABEL];
-  }
-
-  if (Object.hasOwn(config, GROUP)) {
-    tokenType.GROUP = config[GROUP];
-  }
-
-  if (Object.hasOwn(config, POP_MODE)) {
-    tokenType.POP_MODE = config[POP_MODE];
-  }
-
-  if (Object.hasOwn(config, PUSH_MODE)) {
-    tokenType.PUSH_MODE = config[PUSH_MODE];
-  }
-
-  if (Object.hasOwn(config, LONGER_ALT)) {
-    tokenType.LONGER_ALT = config[LONGER_ALT];
-  }
-
-  if (Object.hasOwn(config, LINE_BREAKS)) {
-    tokenType.LINE_BREAKS = config[LINE_BREAKS];
-  }
-
-  if (Object.hasOwn(config, START_CHARS_HINT)) {
-    tokenType.START_CHARS_HINT = config[START_CHARS_HINT];
-  }
 
   return tokenType;
 }
 
 export const EOF = createToken({ name: "EOF", pattern: Lexer.NA });
-augmentTokenTypes([EOF]);
 
 export function createTokenInstance(
   tokType: TokenType,

--- a/packages/chevrotain/test/scan/lexer_spec.ts
+++ b/packages/chevrotain/test/scan/lexer_spec.ts
@@ -18,6 +18,8 @@ import {
   findStartOfInputAnchor,
   findUnreachablePatterns,
   findUnsupportedFlags,
+  performRuntimeChecks,
+  performWarningRuntimeChecks,
 } from "../../src/scan/lexer.js";
 import { setEquality } from "../utils/matchers.js";
 import { tokenStructuredMatcher } from "../../src/scan/tokens.js";
@@ -584,6 +586,81 @@ function defineLexerSpecs(
             LexerDefinitionErrorType.INVALID_GROUP_TYPE_FOUND,
           );
           expect(errors[0].message).to.contain("InvalidGroupNumber");
+        });
+
+        it("accepts inherited PATTERN metadata", () => {
+          const tokenType = Object.create({
+            PATTERN: /abc/,
+          }) as TokenType;
+          tokenType.name = "InheritedPattern";
+
+          const result = findMissingPatterns([tokenType]);
+
+          expect(result.errors).to.be.empty;
+          expect(result.valid).to.deep.equal([tokenType]);
+        });
+
+        it("accepts inherited GROUP metadata", () => {
+          const tokenType = Object.create({
+            GROUP: Lexer.SKIPPED,
+          }) as TokenType;
+          tokenType.name = "InheritedGroup";
+          tokenType.PATTERN = /abc/;
+
+          const errors = findInvalidGroupType([tokenType]);
+
+          expect(errors).to.be.empty;
+        });
+
+        it("accepts inherited LONGER_ALT metadata in runtime checks", () => {
+          const longerAlt = createToken({
+            name: "LongerAlt",
+            pattern: /abc/,
+          });
+          const tokenType = Object.create({
+            LONGER_ALT: longerAlt,
+          }) as TokenType;
+          tokenType.name = "InheritedLongerAlt";
+          tokenType.PATTERN = /ab/;
+
+          const errors = performRuntimeChecks(
+            {
+              defaultMode: "defaultMode",
+              modes: {
+                defaultMode: [tokenType],
+              },
+            },
+            false,
+            ["\r", "\n"],
+          );
+
+          expect(errors).to.have.length(1);
+          expect(errors[0].type).to.equal(
+            LexerDefinitionErrorType.MULTI_MODE_LEXER_LONGER_ALT_NOT_IN_CURRENT_MODE,
+          );
+          expect(errors[0].message).to.contain("InheritedLongerAlt");
+          expect(errors[0].message).to.contain("LongerAlt");
+        });
+
+        it("accepts inherited LINE_BREAKS metadata in warning checks", () => {
+          const tokenType = Object.create({
+            LINE_BREAKS: true,
+          }) as TokenType;
+          tokenType.name = "InheritedLineBreaks";
+          tokenType.PATTERN = / /;
+
+          const warnings = performWarningRuntimeChecks(
+            {
+              defaultMode: "defaultMode",
+              modes: {
+                defaultMode: [tokenType],
+              },
+            },
+            true,
+            ["\r", "\n"],
+          );
+
+          expect(warnings).to.be.empty;
         });
       });
     }

--- a/packages/chevrotain/test/scan/token_spec.ts
+++ b/packages/chevrotain/test/scan/token_spec.ts
@@ -8,7 +8,7 @@ import {
 import { Lexer } from "../../src/scan/lexer_public.js";
 import { singleAssignCategoriesToksMap } from "../../src/scan/tokens.js";
 import { expect } from "chai";
-import { TokenType } from "@chevrotain/types";
+import { ITokenConfig, TokenType } from "@chevrotain/types";
 
 describe("The Chevrotain Tokens namespace", () => {
   context("createToken", () => {
@@ -178,6 +178,36 @@ describe("The Chevrotain Tokens namespace", () => {
           parent: "oops",
         }),
       ).to.throw("The parent property is no longer supported");
+    });
+
+    it("can read inherited token config properties", () => {
+      const Category = createToken({ name: "Category" });
+      const LongerAlt = createToken({ name: "LongerAlt" });
+      const baseConfig = {
+        pattern: /\nfoo/,
+        categories: Category,
+        label: "Foo",
+        group: Lexer.SKIPPED,
+        push_mode: "attribute",
+        pop_mode: true,
+        longer_alt: LongerAlt,
+        line_breaks: true,
+        start_chars_hint: ["f"],
+      };
+      const config = Object.create(baseConfig) as ITokenConfig;
+      config.name = "InheritedConfigTok";
+
+      const tokType = createToken(config);
+
+      expect(tokType.PATTERN).to.equal(baseConfig.pattern);
+      expect(tokType.CATEGORIES).to.deep.equal([Category]);
+      expect(tokType.LABEL).to.equal("Foo");
+      expect(tokType.GROUP).to.equal(Lexer.SKIPPED);
+      expect(tokType.PUSH_MODE).to.equal("attribute");
+      expect(tokType.POP_MODE).to.be.true;
+      expect(tokType.LONGER_ALT).to.equal(LongerAlt);
+      expect(tokType.LINE_BREAKS).to.be.true;
+      expect(tokType.START_CHARS_HINT).to.deep.equal(["f"]);
     });
 
     it("will not go into infinite loop due to cyclic categories", () => {


### PR DESCRIPTION
## Summary
This extracts the inherited token-config handling from the larger PR into a small lexer-focused fix.

It makes `createToken()` and the lexer-side validation/runtime checks treat inherited token metadata the same as own properties for:
- `PATTERN`
- `GROUP`
- `LONGER_ALT`
- `LINE_BREAKS`
- token config values passed through `createToken()`

## Why
Some users build token definitions and config objects via inheritance. The current implementation mixes `Object.hasOwn(...)` checks with normal property access, which means inherited metadata can be ignored in some paths even though it is visible in others.

This PR makes that behavior consistent and adds focused tests for it.

## Tests
- added `createToken()` coverage for inherited config values
- added lexer validation/runtime coverage for inherited `PATTERN`, `GROUP`, `LONGER_ALT`, and `LINE_BREAKS`
- ran scan tests in the extracted branch

## Benchmark note
I ran the benchmark harness against this branch from a separate benchmark worktree to avoid mixing histories. I did not find a clear, stable performance signal to claim here. The setup phases were effectively parity, and warm-lex throughput was mixed/noisy across fixtures.

So I am presenting this as a correctness PR, not a performance PR.