### PR TITLE
feat: wip on lexer optimizations by Matthew

### DIFF
--- a/packages/chevrotain/src/scan/lexer.ts
+++ b/packages/chevrotain/src/scan/lexer.ts
@@ -929,26 +929,6 @@ export function performWarningRuntimeChecks(
   return warnings;
 }
 
-export function cloneEmptyGroups(emptyGroups: {
-  [groupName: string]: IToken;
-}): { [groupName: string]: IToken } {
-  const clonedResult: any = {};
-  const groupKeys = Object.keys(emptyGroups);
-
-  groupKeys.forEach((currKey) => {
-    const currGroupValue = emptyGroups[currKey];
-
-    /* istanbul ignore else */
-    if (Array.isArray(currGroupValue)) {
-      clonedResult[currKey] = [];
-    } else {
-      throw Error("non exhaustive match");
-    }
-  });
-
-  return clonedResult;
-}
-
 // TODO: refactor to avoid duplication
 export function isCustomPattern(tokenType: TokenType): boolean {
   const pattern = tokenType.PATTERN;

--- a/packages/chevrotain/src/scan/lexer_public.ts
+++ b/packages/chevrotain/src/scan/lexer_public.ts
@@ -1,7 +1,6 @@
 import {
   analyzeTokenTypes,
   charCodeToOptimizedIndex,
-  cloneEmptyGroups,
   DEFAULT_MODE,
   IAnalyzeResult,
   IPatternConfig,
@@ -88,6 +87,7 @@ export class Lexer {
   protected modes: string[] = [];
   protected defaultMode!: string;
   protected emptyGroups: { [groupName: string]: IToken } = {};
+  private cachedGroupKeys: string[] = [];
 
   private config: Required<ILexerConfig>;
   private trackStartLines: boolean = true;
@@ -262,6 +262,7 @@ export class Lexer {
       );
 
       this.defaultMode = actualDefinition.defaultMode;
+      this.cachedGroupKeys = Object.keys(this.emptyGroups);
 
       if (
         this.lexerDefinitionErrors.length > 0 &&
@@ -408,7 +409,12 @@ export class Lexer {
     const errors: ILexingError[] = [];
     let line = this.trackStartLines ? 1 : undefined;
     let column = this.trackStartLines ? 1 : undefined;
-    const groups: any = cloneEmptyGroups(this.emptyGroups);
+    const groups: { [groupName: string]: IToken[] } = {};
+    // fast clone implementation for the empty Groups.
+    // provides a slight ~1% performance boost
+    for (let gi = 0; gi < this.cachedGroupKeys.length; gi++) {
+      groups[this.cachedGroupKeys[gi]] = [];
+    }
     const trackLines = this.trackStartLines;
     const lineTerminatorPattern = this.config.lineTerminatorsPattern;
 
@@ -470,8 +476,6 @@ export class Lexer {
         this.charCodeToPatternIdxToConfig[newMode];
 
       patternIdxToConfig = this.patternIdxToConfig[newMode];
-      currModePatternsLength = patternIdxToConfig.length;
-
       currModePatternsLength = patternIdxToConfig.length;
       const modeCanBeOptimized =
         this.canModeBeOptimized[newMode] && this.config.safeMode === false;
@@ -808,7 +812,7 @@ export class Lexer {
     startOffset: number,
     tokenTypeIdx: number,
     tokenType: TokenType,
-  ) {
+  ): IToken {
     return {
       image,
       startOffset,
@@ -824,7 +828,7 @@ export class Lexer {
     tokenType: TokenType,
     startLine: number,
     startColumn: number,
-  ) {
+  ): IToken {
     return {
       image,
       startOffset,


### PR DESCRIPTION
There were 4 lexer related optimizations in the large PR by Matthew

1. Minor cleanups - Remove duplicate line + add : IToken return types
2. cloneEmptyGroups - Inline group cloning with cached keys
3. Monomorphic shape - createToken object literal + all Object.hasOwn → value checks
4. Bitset matching - MATCH_SET Uint32Array in augmentTokenTypes + tokenStructuredMatcher

Only the first two seem relevant (cleanup + minor perf boost)
the third and fourth ones did not seem to provide a perf benefit.



