### PR TITLE
perf: shared K2 lookaheads

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,13 @@
+## Summary
+
+- Optimize static `K=2` lookahead with indexed candidates when paths share a first token.
+- Fall back to the existing lookahead implementation for unsupported cases.
+
+## Performance
+
+- Approximately 20% faster on the ECMAScript 5 parser-only benchmark.
+- JSON and CSS benchmarks are unaffected as they don't use the `K=2` lookahead with shared first tokens.
+
+## Testing
+
+- Add regression coverage for empty-alternative priority in `K=2` lookahead.

--- a/packages/chevrotain/src/parse/grammar/llk_lookahead.ts
+++ b/packages/chevrotain/src/parse/grammar/llk_lookahead.ts
@@ -15,10 +15,10 @@ import {
   validateSomeNonEmptyLookaheadPath,
 } from "./checks.js";
 import {
-  buildAlternativesLookAheadFunc,
+  buildAlternativesLookAheadFuncK2,
   buildLookaheadFuncForOptionalProd,
   buildLookaheadFuncForOr,
-  buildSingleAlternativeLookaheadFunction,
+  buildSingleAlternativeLookaheadFunctionK2,
   getProdType,
 } from "./lookahead.js";
 import { IParserDefinitionError } from "./types.js";
@@ -115,7 +115,7 @@ export class LLkLookaheadStrategy implements ILookaheadStrategy {
       options.maxLookahead,
       options.hasPredicates,
       options.dynamicTokensEnabled,
-      buildAlternativesLookAheadFunc,
+      buildAlternativesLookAheadFuncK2,
     );
   }
 
@@ -132,7 +132,7 @@ export class LLkLookaheadStrategy implements ILookaheadStrategy {
       options.maxLookahead,
       options.dynamicTokensEnabled,
       getProdType(options.prodType),
-      buildSingleAlternativeLookaheadFunction,
+      buildSingleAlternativeLookaheadFunctionK2,
     );
   }
 }

--- a/packages/chevrotain/src/parse/grammar/lookahead.ts
+++ b/packages/chevrotain/src/parse/grammar/lookahead.ts
@@ -18,6 +18,7 @@ import {
 import {
   BaseParser,
   IOrAlt,
+  IToken,
   IProduction,
   IProductionWithOccurrence,
   LookaheadProductionType,
@@ -154,6 +155,155 @@ export function buildLookaheadFuncForOptionalProd(
 }
 
 export type Alternative = TokenType[][];
+
+interface K2OrCandidate {
+  alternative: number;
+  second?: TokenType;
+}
+
+function matchingTokenTypeIdxs(tokenType: TokenType): number[] {
+  return [tokenType.tokenTypeIdx!, ...tokenType.categoryMatches!];
+}
+
+function hasSharedFirstToken(paths: LookaheadSequence): boolean {
+  const seen = new Set<number>();
+  return paths.some((path) => {
+    return (
+      path.length > 0 &&
+      matchingTokenTypeIdxs(path[0]).some((tokenTypeIdx) => {
+        if (seen.has(tokenTypeIdx)) {
+          return true;
+        }
+        seen.add(tokenTypeIdx);
+        return false;
+      })
+    );
+  });
+}
+
+function buildK2AlternativesLookAheadFunc(
+  alts: LookaheadSequence[],
+  tokenMatcher: TokenMatcher,
+): () => number | undefined {
+  const candidatesByFirst: Record<number, K2OrCandidate[]> =
+    Object.create(null);
+  let emptyAlternative: number | undefined;
+
+  alts.forEach((alt, alternative) => {
+    alt.forEach((path) => {
+      if (path.length === 0) {
+        emptyAlternative ??= alternative;
+        return;
+      }
+      matchingTokenTypeIdxs(path[0]).forEach((tokenTypeIdx) => {
+        (candidatesByFirst[tokenTypeIdx] ??= []).push({
+          alternative,
+          second: path[1],
+        });
+      });
+    });
+  });
+
+  return function (this: BaseParser): number | undefined {
+    const candidates = candidatesByFirst[this.LA_FAST(1).tokenTypeIdx];
+    if (candidates === undefined) {
+      return emptyAlternative;
+    }
+
+    let secondToken: IToken | undefined;
+    for (let i = 0; i < candidates.length; i++) {
+      const candidate = candidates[i];
+      if (
+        emptyAlternative !== undefined &&
+        emptyAlternative < candidate.alternative
+      ) {
+        return emptyAlternative;
+      }
+      if (candidate.second === undefined) {
+        return candidate.alternative;
+      }
+      secondToken ??= this.LA_FAST(2);
+      if (tokenMatcher(secondToken, candidate.second)) {
+        return candidate.alternative;
+      }
+    }
+    return emptyAlternative;
+  };
+}
+
+function buildK2SingleAlternativeLookaheadFunction(
+  alt: LookaheadSequence,
+  tokenMatcher: TokenMatcher,
+): () => boolean {
+  const candidatesByFirst: Record<number, (TokenType | undefined)[]> =
+    Object.create(null);
+
+  alt.forEach((path) => {
+    matchingTokenTypeIdxs(path[0]).forEach((tokenTypeIdx) => {
+      (candidatesByFirst[tokenTypeIdx] ??= []).push(path[1]);
+    });
+  });
+
+  return function (this: BaseParser): boolean {
+    const candidates = candidatesByFirst[this.LA_FAST(1).tokenTypeIdx];
+    if (candidates === undefined) {
+      return false;
+    }
+
+    let secondToken: IToken | undefined;
+    for (let i = 0; i < candidates.length; i++) {
+      const second = candidates[i];
+      if (second === undefined) {
+        return true;
+      }
+      secondToken ??= this.LA_FAST(2);
+      if (tokenMatcher(secondToken, second)) {
+        return true;
+      }
+    }
+    return false;
+  };
+}
+
+export function buildAlternativesLookAheadFuncK2(
+  alts: LookaheadSequence[],
+  hasPredicates: boolean,
+  tokenMatcher: TokenMatcher,
+  dynamicTokensEnabled: boolean,
+): (orAlts: IOrAlt<any>[]) => number | undefined {
+  const maxPathLength = Math.max(
+    ...alts.flatMap((alt) => alt.map((path) => path.length)),
+  );
+  return !hasPredicates &&
+    !dynamicTokensEnabled &&
+    maxPathLength === 2 &&
+    hasSharedFirstToken(alts.flat())
+    ? buildK2AlternativesLookAheadFunc(alts, tokenMatcher)
+    : buildAlternativesLookAheadFunc(
+        alts,
+        hasPredicates,
+        tokenMatcher,
+        dynamicTokensEnabled,
+      );
+}
+
+export function buildSingleAlternativeLookaheadFunctionK2(
+  alt: LookaheadSequence,
+  tokenMatcher: TokenMatcher,
+  dynamicTokensEnabled: boolean,
+): () => boolean {
+  const maxPathLength = Math.max(...alt.map((path) => path.length));
+  return !dynamicTokensEnabled &&
+    maxPathLength === 2 &&
+    alt.every((path) => path.length > 0) &&
+    hasSharedFirstToken(alt)
+    ? buildK2SingleAlternativeLookaheadFunction(alt, tokenMatcher)
+    : buildSingleAlternativeLookaheadFunction(
+        alt,
+        tokenMatcher,
+        dynamicTokensEnabled,
+      );
+}
 
 export function buildAlternativesLookAheadFunc(
   alts: LookaheadSequence[],

--- a/packages/chevrotain/test/parse/grammar/lookahead_spec.ts
+++ b/packages/chevrotain/test/parse/grammar/lookahead_spec.ts
@@ -2,6 +2,7 @@ import { END_OF_FILE } from "../../../src/parse/parser/parser.js";
 import { createToken } from "../../../src/scan/tokens_public.js";
 import {
   buildAlternativesLookAheadFunc,
+  buildAlternativesLookAheadFuncK2,
   buildLookaheadFuncForOptionalProd,
   buildLookaheadFuncForOr,
   buildSingleAlternativeLookaheadFunction,
@@ -947,6 +948,18 @@ context("lookahead specs", () => {
         expect(laFunc.call(new MockParser([Alpha]))).to.equal(0);
         expect(laFunc.call(new MockParser([]))).to.equal(1); // empty alternative always matches
         expect(laFunc.call(new MockParser([Delta]))).to.equal(1); // empty alternative always matches
+      });
+
+      it("preserves empty alternative priority with K=2 paths", () => {
+        const laFunc = buildAlternativesLookAheadFuncK2(
+          [[[Alpha, Beta]], [[]], [[Alpha, Gamma]]],
+          false,
+          tokenStructuredMatcher,
+          false,
+        );
+
+        expect(laFunc.call(new MockParser([Alpha, Beta]))).to.equal(0);
+        expect(laFunc.call(new MockParser([Alpha, Gamma]))).to.equal(1);
       });
 
       it("simple optional - positive", () => {


### PR DESCRIPTION
## Summary

- Optimize static `K=2` lookahead with indexed candidates when paths share a first token.
- Fall back to the existing lookahead implementation for unsupported cases.

## Performance

- Approximately 20% faster on the ECMAScript 5 parser-only benchmark.
- JSON and CSS benchmarks are unaffected as they don't use the `K=2` lookahead with shared first tokens.

<img width="1668" height="942" alt="image" src="https://github.com/user-attachments/assets/7e722264-c6b7-4ce8-a663-6eea91fa4fa9" />


## Testing

- Add regression coverage for empty-alternative priority in `K=2` lookahead.
