### PR TITLE
perf: ascii-class-scanner

### DIFF
--- a/packages/chevrotain/src/scan/lexer.ts
+++ b/packages/chevrotain/src/scan/lexer.ts
@@ -1,4 +1,4 @@
-import { BaseRegExpVisitor } from "@chevrotain/regexp-to-ast";
+import { BaseRegExpVisitor, Quantifier, Set } from "@chevrotain/regexp-to-ast";
 import {
   IRegExpExec,
   Lexer,
@@ -27,14 +27,17 @@ export const MODES = "modes";
 export const SINGLE_CHAR_MATCH = 0;
 export const CUSTOM_MATCH = 1;
 export const REG_EXP_MATCH = 2;
+export const ASCII_CLASS_MATCH = 3;
 
 type MatchType =
   | typeof SINGLE_CHAR_MATCH
   | typeof CUSTOM_MATCH
-  | typeof REG_EXP_MATCH;
+  | typeof REG_EXP_MATCH
+  | typeof ASCII_CLASS_MATCH;
 
 export interface IPatternConfig {
   pattern: IRegExpExec | string;
+  asciiClass: Uint8Array | undefined;
   longerAlt: number[] | undefined;
   canLineTerminator: boolean;
   matchType: MatchType;
@@ -249,16 +252,25 @@ export function analyzeTokenTypes(
 
     patternIdxToConfig = allTransformedPatterns.map(
       (x, idx): IPatternConfig => {
+        const asciiClass =
+          patternIdxToGroup[idx] === undefined &&
+          patternIdxToLongerAltIdxArr[idx] === undefined
+            ? getAsciiClass(onlyRelevantTypes[idx].PATTERN)
+            : undefined;
+
         return {
           pattern: allTransformedPatterns[idx],
+          asciiClass,
           longerAlt: patternIdxToLongerAltIdxArr[idx],
           canLineTerminator: patternIdxToCanLineTerminator[idx],
           matchType:
-            patternIdxToShort[idx] !== false
-              ? SINGLE_CHAR_MATCH
-              : patternIdxToIsCustom[idx]
-                ? CUSTOM_MATCH
-                : REG_EXP_MATCH,
+            asciiClass !== undefined
+              ? ASCII_CLASS_MATCH
+              : patternIdxToShort[idx] !== false
+                ? SINGLE_CHAR_MATCH
+                : patternIdxToIsCustom[idx]
+                  ? CUSTOM_MATCH
+                  : REG_EXP_MATCH,
           short: patternIdxToShort[idx],
           group: patternIdxToGroup[idx],
           push: patternIdxToPushMode[idx],
@@ -359,6 +371,70 @@ export function analyzeTokenTypes(
     hasCustom: hasCustom,
     canBeOptimized: canBeOptimized,
   };
+}
+
+function getAsciiClass(pattern: unknown): Uint8Array | undefined {
+  // Flags may change character-set semantics, so only analyze plain RegExps.
+  if (!(pattern instanceof RegExp) || pattern.flags !== "") {
+    return undefined;
+  }
+
+  let ast;
+  try {
+    ast = getRegExpAst(pattern);
+  } catch {
+    return undefined;
+  }
+
+  // The fast scanner can only replace one alternative containing one atom.
+  if (ast.value.value.length !== 1 || ast.value.value[0].value.length !== 1) {
+    return undefined;
+  }
+
+  // Unwrap noncapturing single-atom groups while retaining the sole quantifier.
+  let atom = ast.value.value[0].value[0];
+  let quantifier: Quantifier | undefined;
+  while (atom.type === "Group") {
+    if (
+      atom.capturing ||
+      (atom.quantifier !== undefined && quantifier !== undefined) ||
+      atom.value.value.length !== 1 ||
+      atom.value.value[0].value.length !== 1
+    ) {
+      return undefined;
+    }
+    quantifier = atom.quantifier ?? quantifier;
+    atom = atom.value.value[0].value[0];
+  }
+
+  // The remaining atom must be a non-complement set repeated greedily 1+ times.
+  if (
+    atom.type !== "Set" ||
+    atom.complement ||
+    (atom.quantifier !== undefined && quantifier !== undefined)
+  ) {
+    return undefined;
+  }
+  quantifier = atom.quantifier ?? quantifier;
+  if (
+    quantifier?.atLeast !== 1 ||
+    quantifier.atMost !== Infinity ||
+    !quantifier.greedy
+  ) {
+    return undefined;
+  }
+
+  // Materialize ASCII membership, rejecting any code point outside the table.
+  const result = new Uint8Array(128);
+  for (const item of (atom as Set).value) {
+    const from = typeof item === "number" ? item : item.from;
+    const to = typeof item === "number" ? item : item.to;
+    if (from < 0 || to >= result.length) {
+      return undefined;
+    }
+    result.fill(1, from, to + 1);
+  }
+  return result;
 }
 
 export function validatePatterns(

--- a/packages/chevrotain/src/scan/lexer_public.ts
+++ b/packages/chevrotain/src/scan/lexer_public.ts
@@ -1,5 +1,6 @@
 import {
   analyzeTokenTypes,
+  ASCII_CLASS_MATCH,
   charCodeToOptimizedIndex,
   CUSTOM_MATCH,
   DEFAULT_MODE,
@@ -546,6 +547,20 @@ export class Lexer {
               matchedImage = null;
             }
             break;
+          case ASCII_CLASS_MATCH: {
+            const asciiClass = currConfig.asciiClass!;
+            if (asciiClass[nextCharCode] !== 1) {
+              (currPattern as RegExp).lastIndex = 0;
+              break;
+            }
+            let endOffset = offset + 1;
+            while (asciiClass[orgText.charCodeAt(endOffset)] === 1) {
+              endOffset++;
+            }
+            imageLength = endOffset - offset;
+            (currPattern as RegExp).lastIndex = endOffset;
+            break;
+          }
           case REG_EXP_MATCH:
             (currPattern as RegExp).lastIndex = offset;
             imageLength = this.matchLength(currPattern as RegExp, text, offset);
@@ -712,6 +727,7 @@ export class Lexer {
                     groups,
                   ) !== null;
                 break;
+              case ASCII_CLASS_MATCH:
               case REG_EXP_MATCH:
                 (currPattern as RegExp).lastIndex = offset;
                 foundResyncPoint = (currPattern as RegExp).exec(text) !== null;

--- a/packages/chevrotain/test/scan/regexp_spec.ts
+++ b/packages/chevrotain/test/scan/regexp_spec.ts
@@ -5,6 +5,7 @@ import {
   getOptimizedStartCodesIndices,
 } from "../../src/scan/reg_exp.js";
 import { expect } from "chai";
+import { analyzeTokenTypes } from "../../src/scan/lexer.js";
 
 describe("The Chevrotain regexp analysis", () => {
   it("Will re-attempt none 'optimized' patterns if the optimization failed", () => {
@@ -32,6 +33,124 @@ describe("The Chevrotain regexp analysis", () => {
     const lexResult = JsonLexer.tokenize("fool");
     expect(lexResult.tokens).to.have.lengthOf(1);
     expect(lexResult.tokens[0].tokenType).to.equal(Name);
+  });
+});
+
+describe("ASCII character class scanning", () => {
+  function getAsciiClass(pattern: RegExp) {
+    const Skipped = createToken({
+      name: `Skipped${pattern}`,
+      pattern,
+      group: Lexer.SKIPPED,
+    });
+    return analyzeTokenTypes([Skipped], {}).patternIdxToConfig[0].asciiClass;
+  }
+
+  it("recognizes JSON and CSS whitespace without conflating form feed", () => {
+    const json = getAsciiClass(/[ \t\n\r]+/)!;
+    const css = getAsciiClass(/(?:[ \t\r\n\f]){1,}/)!;
+
+    expect(json[32]).to.equal(1);
+    expect(json[12]).to.equal(0);
+    expect(css[12]).to.equal(1);
+
+    const X = createToken({ name: "AsciiX", pattern: /x/ });
+    const makeLexer = (pattern: RegExp) =>
+      new Lexer(
+        [
+          createToken({
+            name: `FormFeed${pattern}`,
+            pattern,
+            group: Lexer.SKIPPED,
+          }),
+          X,
+        ],
+        { positionTracking: "onlyOffset" },
+      );
+    expect(makeLexer(/[ \t\n\r]+/).tokenize("\fx").errors).to.have.lengthOf(1);
+    expect(makeLexer(/[ \t\n\r\f]+/).tokenize("\fx").errors).to.be.empty;
+  });
+
+  it("rejects patterns whose equivalence is not safely provable", () => {
+    const patterns = [
+      /[ \t]+?/,
+      /[^a]+/,
+      /[ a\u00a0]+/,
+      /[ a]+/i,
+      /([ a])+/,
+      /(?=[ a])[ a]+/,
+      /([ a])\1+/,
+    ];
+
+    for (const pattern of patterns) {
+      expect(getAsciiClass(pattern), pattern.toString()).to.be.undefined;
+    }
+  });
+
+  it("falls back to RegExp semantics for rejected patterns", () => {
+    const cases: [RegExp, string, string][] = [
+      [/[ a]+?/, "  x", "x"],
+      [/[^a]+/, "bbba", "a"],
+      [/[\u00a0]+/, "\u00a0x", "x"],
+      [/[a]+/i, "AAx", "x"],
+      [/([a])+/, "aax", "x"],
+      [/(?=a)[a]+/, "aax", "x"],
+      [/(a)\1+/, "aaax", "x"],
+    ];
+
+    for (const [pattern, input, remainder] of cases) {
+      const Skipped = createToken({
+        name: `Fallback${pattern}`,
+        pattern,
+        group: Lexer.SKIPPED,
+      });
+      const Any = createToken({ name: `Any${pattern}`, pattern: /./ });
+      const result = new Lexer([Skipped, Any], {
+        positionTracking: "onlyOffset",
+      }).tokenize(input);
+
+      expect(result.errors, pattern.toString()).to.be.empty;
+      expect(
+        result.tokens.map((token) => token.image).join(""),
+        pattern.toString(),
+      ).to.equal(remainder);
+    }
+  });
+
+  it("preserves tokenization and sticky lastIndex behavior", () => {
+    const Whitespace = createToken({
+      name: "AsciiWhitespace",
+      pattern: /[ \t]+/,
+      group: Lexer.SKIPPED,
+    });
+    const A = createToken({ name: "AsciiA", pattern: /a+/ });
+    class InspectableLexer extends Lexer {
+      get whitespacePattern() {
+        return this.patternIdxToConfig.defaultMode[0].pattern as RegExp;
+      }
+    }
+    const lexer = new InspectableLexer([Whitespace, A], { safeMode: true });
+
+    expect(lexer.tokenize(" \t").tokens).to.be.empty;
+    expect(lexer.whitespacePattern.lastIndex).to.equal(2);
+    expect(
+      lexer.tokenize("a").tokens.map((token) => token.image),
+    ).to.deep.equal(["a"]);
+    expect(lexer.whitespacePattern.lastIndex).to.equal(0);
+  });
+
+  it("does not scan skipped patterns with longer alternatives", () => {
+    const Longer = createToken({ name: "AsciiLonger", pattern: /[ a]+/ });
+    const Skipped = createToken({
+      name: "AsciiSkippedLongerAlt",
+      pattern: /[ a]+/,
+      group: Lexer.SKIPPED,
+      longer_alt: Longer,
+    });
+
+    expect(
+      analyzeTokenTypes([Skipped, Longer], {}).patternIdxToConfig[0].asciiClass,
+    ).to.be.undefined;
   });
 });
 

--- a/packages/chevrotain/test/scan/regexp_spec.ts
+++ b/packages/chevrotain/test/scan/regexp_spec.ts
@@ -73,47 +73,17 @@ describe("ASCII character class scanning", () => {
 
   it("rejects patterns whose equivalence is not safely provable", () => {
     const patterns = [
-      /[ \t]+?/,
-      /[^a]+/,
-      /[ a\u00a0]+/,
-      /[ a]+/i,
-      /([ a])+/,
-      /(?=[ a])[ a]+/,
-      /([ a])\1+/,
+      /[ \t]+?/, // lazy quantifier
+      /[^a]+/, // complemented character class
+      /[ a\u00a0]+/, // contains a non-ASCII character
+      /[ a]+/i, // uses a RegExp flag
+      /([ a])+/, // uses a capturing group
+      /(?=[ a])[ a]+/, // uses a lookahead assertion
+      /([ a])\1+/, // uses a backreference
     ];
 
     for (const pattern of patterns) {
       expect(getAsciiClass(pattern), pattern.toString()).to.be.undefined;
-    }
-  });
-
-  it("falls back to RegExp semantics for rejected patterns", () => {
-    const cases: [RegExp, string, string][] = [
-      [/[ a]+?/, "  x", "x"],
-      [/[^a]+/, "bbba", "a"],
-      [/[\u00a0]+/, "\u00a0x", "x"],
-      [/[a]+/i, "AAx", "x"],
-      [/([a])+/, "aax", "x"],
-      [/(?=a)[a]+/, "aax", "x"],
-      [/(a)\1+/, "aaax", "x"],
-    ];
-
-    for (const [pattern, input, remainder] of cases) {
-      const Skipped = createToken({
-        name: `Fallback${pattern}`,
-        pattern,
-        group: Lexer.SKIPPED,
-      });
-      const Any = createToken({ name: `Any${pattern}`, pattern: /./ });
-      const result = new Lexer([Skipped, Any], {
-        positionTracking: "onlyOffset",
-      }).tokenize(input);
-
-      expect(result.errors, pattern.toString()).to.be.empty;
-      expect(
-        result.tokens.map((token) => token.image).join(""),
-        pattern.toString(),
-      ).to.equal(remainder);
     }
   });
 
@@ -124,15 +94,22 @@ describe("ASCII character class scanning", () => {
       group: Lexer.SKIPPED,
     });
     const A = createToken({ name: "AsciiA", pattern: /a+/ });
+
+    // Expose the transformed sticky RegExp to inspect the scanner's emulated state.
     class InspectableLexer extends Lexer {
       get whitespacePattern() {
         return this.patternIdxToConfig.defaultMode[0].pattern as RegExp;
       }
     }
+
+    // Force every pattern to be attempted, including whitespace on non-whitespace.
     const lexer = new InspectableLexer([Whitespace, A], { safeMode: true });
 
+    // A successful sticky match advances lastIndex to the end of the match.
     expect(lexer.tokenize(" \t").tokens).to.be.empty;
     expect(lexer.whitespacePattern.lastIndex).to.equal(2);
+
+    // A failed sticky match resets lastIndex while the next pattern still matches.
     expect(
       lexer.tokenize("a").tokens.map((token) => token.image),
     ).to.deep.equal(["a"]);


### PR DESCRIPTION
# Summary

Optimize skipped tokens whose patterns are provably equivalent to a greedy repetition of an ASCII character class.

During lexer analysis, eligible patterns receive a 128-entry membership table. The lexer then scans matching input with `charCodeAt` instead of repeatedly invoking the RegExp engine. Patterns that do not meet every eligibility requirement continue through the existing RegExp path.

## Eligibility

The fast path is deliberately limited to skipped token patterns with:

- A single non-complement ASCII character set.
- A greedy `+` or `{1,}` quantifier.
- Optional noncapturing group wrappers.
- No RegExp flags, captures, assertions, backreferences, `longer_alt`, or custom matcher.

The implementation preserves the transformed sticky RegExp's `lastIndex` behavior on both success and failure.

## Performance

<img width="1442" height="804" alt="image" src="https://github.com/user-attachments/assets/ef5d0d5e-d03b-4d5d-b69c-aa1dae6d754a" />


