### PR TITLE
refactor: use switch for lexer strategy

### DIFF
--- a/packages/chevrotain/src/scan/lexer.ts
+++ b/packages/chevrotain/src/scan/lexer.ts
@@ -24,11 +24,20 @@ const PATTERN = "PATTERN";
 export const DEFAULT_MODE = "defaultMode";
 export const MODES = "modes";
 
+export const SINGLE_CHAR_MATCH = 0;
+export const CUSTOM_MATCH = 1;
+export const REG_EXP_MATCH = 2;
+
+type MatchType =
+  | typeof SINGLE_CHAR_MATCH
+  | typeof CUSTOM_MATCH
+  | typeof REG_EXP_MATCH;
+
 export interface IPatternConfig {
   pattern: IRegExpExec | string;
   longerAlt: number[] | undefined;
   canLineTerminator: boolean;
-  isCustom: boolean;
+  matchType: MatchType;
   short: number | false;
   group: string | undefined | false;
   push: string | undefined;
@@ -244,7 +253,12 @@ export function analyzeTokenTypes(
           pattern: allTransformedPatterns[idx],
           longerAlt: patternIdxToLongerAltIdxArr[idx],
           canLineTerminator: patternIdxToCanLineTerminator[idx],
-          isCustom: patternIdxToIsCustom[idx],
+          matchType:
+            patternIdxToShort[idx] !== false
+              ? SINGLE_CHAR_MATCH
+              : patternIdxToIsCustom[idx]
+                ? CUSTOM_MATCH
+                : REG_EXP_MATCH,
           short: patternIdxToShort[idx],
           group: patternIdxToGroup[idx],
           push: patternIdxToPushMode[idx],

--- a/packages/chevrotain/src/scan/lexer_public.ts
+++ b/packages/chevrotain/src/scan/lexer_public.ts
@@ -1,12 +1,15 @@
 import {
   analyzeTokenTypes,
   charCodeToOptimizedIndex,
+  CUSTOM_MATCH,
   DEFAULT_MODE,
   IAnalyzeResult,
   IPatternConfig,
   LineTerminatorOptimizedTester,
   performRuntimeChecks,
   performWarningRuntimeChecks,
+  REG_EXP_MATCH,
+  SINGLE_CHAR_MATCH,
   validatePatterns,
 } from "./lexer.js";
 import { PRINT_WARNING, timer, toFastProperties } from "@chevrotain/utils";
@@ -518,32 +521,35 @@ export class Lexer {
         payload = null;
 
         // manually in-lined because > 600 chars won't be in-lined in V8
-        const singleCharCode = currConfig.short;
-        if (singleCharCode !== false) {
-          if (nextCharCode === singleCharCode) {
-            // single character string
-            imageLength = 1;
-            matchedImage = currPattern as string;
-          }
-        } else if (currConfig.isCustom === true) {
-          match = (currPattern as IRegExpExec).exec(
-            orgText,
-            offset,
-            matchedTokens,
-            groups,
-          );
-          if (match !== null) {
-            matchedImage = match[0];
-            imageLength = matchedImage.length;
-            if ((match as CustomPatternMatcherReturn).payload !== undefined) {
-              payload = (match as CustomPatternMatcherReturn).payload;
+        switch (currConfig.matchType) {
+          case SINGLE_CHAR_MATCH:
+            if (nextCharCode === currConfig.short) {
+              // single character string
+              imageLength = 1;
+              matchedImage = currPattern as string;
             }
-          } else {
-            matchedImage = null;
-          }
-        } else {
-          (currPattern as RegExp).lastIndex = offset;
-          imageLength = this.matchLength(currPattern as RegExp, text, offset);
+            break;
+          case CUSTOM_MATCH:
+            match = (currPattern as IRegExpExec).exec(
+              orgText,
+              offset,
+              matchedTokens,
+              groups,
+            );
+            if (match !== null) {
+              matchedImage = match[0];
+              imageLength = matchedImage.length;
+              if ((match as CustomPatternMatcherReturn).payload !== undefined) {
+                payload = (match as CustomPatternMatcherReturn).payload;
+              }
+            } else {
+              matchedImage = null;
+            }
+            break;
+          case REG_EXP_MATCH:
+            (currPattern as RegExp).lastIndex = offset;
+            imageLength = this.matchLength(currPattern as RegExp, text, offset);
+            break;
         }
 
         // longer alts handling
@@ -561,7 +567,7 @@ export class Lexer {
 
               // single Char can never be a longer alt so no need to test it.
               // manually in-lined because > 600 chars won't be in-lined in V8
-              if (longerAltConfig.isCustom === true) {
+              if (longerAltConfig.matchType === CUSTOM_MATCH) {
                 match = (longerAltPattern as IRegExpExec).exec(
                   orgText,
                   offset,
@@ -690,23 +696,26 @@ export class Lexer {
             const currPattern = currConfig.pattern;
 
             // manually in-lined because > 600 chars won't be in-lined in V8
-            const singleCharCode = currConfig.short;
-            if (singleCharCode !== false) {
-              if (orgText.charCodeAt(offset) === singleCharCode) {
-                // single character string
-                foundResyncPoint = true;
-              }
-            } else if (currConfig.isCustom === true) {
-              foundResyncPoint =
-                (currPattern as IRegExpExec).exec(
-                  orgText,
-                  offset,
-                  matchedTokens,
-                  groups,
-                ) !== null;
-            } else {
-              (currPattern as RegExp).lastIndex = offset;
-              foundResyncPoint = (currPattern as RegExp).exec(text) !== null;
+            switch (currConfig.matchType) {
+              case SINGLE_CHAR_MATCH:
+                if (orgText.charCodeAt(offset) === currConfig.short) {
+                  // single character string
+                  foundResyncPoint = true;
+                }
+                break;
+              case CUSTOM_MATCH:
+                foundResyncPoint =
+                  (currPattern as IRegExpExec).exec(
+                    orgText,
+                    offset,
+                    matchedTokens,
+                    groups,
+                  ) !== null;
+                break;
+              case REG_EXP_MATCH:
+                (currPattern as RegExp).lastIndex = offset;
+                foundResyncPoint = (currPattern as RegExp).exec(text) !== null;
+                break;
             }
 
             if (foundResyncPoint === true) {


### PR DESCRIPTION
To prepare for future lexer strategy choices without incurring additional overhead.

This also seems to provide a minor performance benefit in one of the benchmark grammars

<img width="1454" height="782" alt="image" src="https://github.com/user-attachments/assets/23b3699e-0757-40a7-b4cf-eccf3697b037" />
